### PR TITLE
Merge fastcpc

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,8 +4,8 @@
 if [[ "$OSTYPE" == "darwin"* ]]; then
 	SDK_PATH=$(xcrun --sdk macosx --show-sdk-path)
 	export CXX=clang++
-	# github actions macos-latest 1.57.0 fails, so try 1.65.1 instead
-	: ${BOOST_VERSION:=1.65.1}
+	# github actions macos-latest 1.57.0 fails, so try 1.72.0 instead
+	: ${BOOST_VERSION:=1.72.0}
 	echo "[*] Detected macosx: SDK_PATH=${SDK_PATH} BOOST_VERSION=${BOOST_VERSION}"
 fi
 if [ ! -z $(command -v glibtoolize) ]; then

--- a/build.sh
+++ b/build.sh
@@ -4,8 +4,8 @@
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
 	SDK_PATH=$(xcrun --sdk macosx --show-sdk-path)
-	# github actions macos-latest 1.57.0 fails, so try 1.70.0 instead
-	: ${BOOST_VERSION:=1.72.0}
+	# github actions macos-latest 1.57.0 fails, so try 1.73.0 instead
+	: ${BOOST_VERSION:=1.73.0}
 	echo "[*] Detected macosx: SDK_PATH=${SDK_PATH} BOOST_VERSION=${BOOST_VERSION}"
 fi
 if [ ! -z $(command -v glibtoolize) ]; then

--- a/build.sh
+++ b/build.sh
@@ -4,8 +4,8 @@
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
 	SDK_PATH=$(xcrun --sdk macosx --show-sdk-path)
-	# github actions macos-latest 1.57.0 fails, so try 1.74.0 instead
-	: ${BOOST_VERSION:=1.74.0}
+	# github actions macos-latest 1.57.0 fails, so try 1.75.0 instead
+	: ${BOOST_VERSION:=1.75.0}
 	echo "[*] Detected macosx: SDK_PATH=${SDK_PATH} BOOST_VERSION=${BOOST_VERSION}"
 fi
 if [ ! -z $(command -v glibtoolize) ]; then

--- a/build.sh
+++ b/build.sh
@@ -4,8 +4,8 @@
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
 	SDK_PATH=$(xcrun --sdk macosx --show-sdk-path)
-	# github actions macos-latest 1.57.0 fails, so try 1.73.0 instead
-	: ${BOOST_VERSION:=1.73.0}
+	# github actions macos-latest 1.57.0 fails, so try 1.74.0 instead
+	: ${BOOST_VERSION:=1.74.0}
 	echo "[*] Detected macosx: SDK_PATH=${SDK_PATH} BOOST_VERSION=${BOOST_VERSION}"
 fi
 if [ ! -z $(command -v glibtoolize) ]; then

--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 # check for special configuration for macosx
-
 if [[ "$OSTYPE" == "darwin"* ]]; then
 	SDK_PATH=$(xcrun --sdk macosx --show-sdk-path)
-	# github actions macos-latest 1.57.0 fails, so try 1.75.0 instead
-	: ${BOOST_VERSION:=1.75.0}
+	export CXX=clang++
+	# github actions macos-latest 1.57.0 fails, so try 1.65.1 instead
+	: ${BOOST_VERSION:=1.65.1}
 	echo "[*] Detected macosx: SDK_PATH=${SDK_PATH} BOOST_VERSION=${BOOST_VERSION}"
 fi
 if [ ! -z $(command -v glibtoolize) ]; then
@@ -18,10 +18,9 @@ fi
 # default values for boost library version and install location
 # (if not already defined in environment)
 
-: ${BOOST_VERSION:=1.57.0}
+: ${BOOST_VERSION:=1.65.1}
 : ${BOOST_INSTALL_PREFIX:=$(pwd)/boost-$BOOST_VERSION}
 : ${INCLUDE_DIRS:="/usr/include /usr/local/include $SDK_PATH/usr/include"}
-
 
 # helper functions
 

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 
 
-DEFAULT_CXXFLAGS="-O3"
+DEFAULT_CXXFLAGS="-O3 -march=native -DNDEBUG"
 AS_IF([test "x$CXXFLAGS" = "x"],
 	[CXXFLAGS="$DEFAULT_CXXFLAGS"]
 	[usedefaultcxxflags=yes],

--- a/install_boost.sh
+++ b/install_boost.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-: ${BOOST_VERSION:=1.57.0}
+: ${BOOST_VERSION:=1.65.1}
 : ${BOOST_BUILD_OPTIONS:="-j4 --with-filesystem --with-iostreams --with-program_options --with-serialization --with-system --with-thread"}
 : ${BOOST_BUILD_CXXFLAGS:="-O2"}
 : ${BOOST_INSTALL_PREFIX:=$(pwd)/boost-$BOOST_VERSION}

--- a/lib/hashclash/differentialpath.hpp
+++ b/lib/hashclash/differentialpath.hpp
@@ -41,7 +41,7 @@ namespace hashclash {
 	double test_path(const differentialpath& path, const uint32 blockdiff[]);	
 	double check_rotation(uint32 dR, uint32 dT, unsigned n, const wordconditions& Qt, const wordconditions& Qtp1, unsigned loopcount = (1<<10));
 
-	bool test_path_fast(const differentialpath& path, const uint32 blockdiff[]);
+	bool test_path_fast(const differentialpath& path, const uint32 blockdiff[], int tbegin = 0, int tend = 64);
 	bool check_rotation_fast(uint32 dR, uint32 dT, unsigned n, const wordconditions& Qt, const wordconditions& Qtp1, unsigned loopcount = (1<<10));
 
 	// cleans up differential path to backward conditions only

--- a/lib/hashclash/differentialpath.hpp
+++ b/lib/hashclash/differentialpath.hpp
@@ -150,56 +150,36 @@ namespace hashclash {
 		{
 			return !(*this == r);
 		}
+
+		bool operator<(const differentialpath& r) const
+		{
+			const differentialpath& l = *this;
+			int tbegin = l.tbegin() < r.tbegin() ? l.tbegin() : r.tbegin();
+			for (int t = tbegin; t < l.tend() || t < r.tend(); ++t)
+			{
+				if (t >= l.tbegin() && t < l.tend()) {
+					if (t >= r.tbegin() && t < r.tend()) {
+						if (l[t] < r[t]) return true;
+						if (l[t] > r[t]) return false;
+					} else {
+						if (l[t] < wordconditions()) return true;
+						if (l[t] > wordconditions()) return false;
+					}
+				} else
+				{
+					if (t >= r.tbegin() && t < r.tend()) {
+						if (wordconditions() < r[t]) return true;
+						if (wordconditions() > r[t]) return false;
+					}
+				}
+			}
+			return false;
+		}
+
 	//private:
 		int offset;
 		std::vector<wordconditions> path;
 	};
-
-	inline bool operator== (const differentialpath& l, const differentialpath& r)
-	{
-		int tbegin = l.tbegin() < r.tbegin() ? l.tbegin() : r.tbegin();
-		for (int t = tbegin; t < l.tend() || t < r.tend(); ++t)
-		{
-			if (t >= l.tbegin() && t < l.tend()) {
-				if (t >= r.tbegin() && t < r.tend()) {
-					if (l[t] != r[t]) 
-						return false;
-				} else
-					if (l[t] != wordconditions()) 
-						return false;
-			} else
-			{
-				if (t >= r.tbegin() && t < r.tend())
-					if (wordconditions() != r[t]) 
-						return false;
-			}
-		}
-		return true;
-	}
-
-	inline bool operator< (const differentialpath& l, const differentialpath& r)
-	{
-		int tbegin = l.tbegin() < r.tbegin() ? l.tbegin() : r.tbegin();
-		for (int t = tbegin; t < l.tend() || t < r.tend(); ++t)
-		{
-			if (t >= l.tbegin() && t < l.tend()) {
-				if (t >= r.tbegin() && t < r.tend()) {
-					if (l[t] < r[t]) return true;
-					if (l[t] > r[t]) return false;
-				} else {
-					if (l[t] < wordconditions()) return true;
-					if (l[t] > wordconditions()) return false;
-				}
-			} else
-			{
-				if (t >= r.tbegin() && t < r.tend()) {
-					if (wordconditions() < r[t]) return true;
-					if (wordconditions() > r[t]) return false;
-				} 
-			}
-		}
-		return false;
-	}
 
 } // namespace hashclash
 

--- a/lib/hashclash/saveload_gz.hpp
+++ b/lib/hashclash/saveload_gz.hpp
@@ -52,7 +52,7 @@ namespace hashclash {
 		std::ofstream ofs(filepath.string().c_str(), std::ios::binary);
         if (!ofs) throw std::runtime_error("save_gz(): could not open file!");
         boost::iostreams::filtering_ostream filter;
-        filter.push(boost::iostreams::gzip_compressor());
+        filter.push(boost::iostreams::gzip_compressor(boost::iostreams::gzip::best_speed));
         filter.push(ofs);
         switch (artype) {
 			case binary_archive:

--- a/m4/ax_boost_base.m4
+++ b/m4/ax_boost_base.m4
@@ -125,12 +125,17 @@ AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
       [multiarch_libsubdir="lib/${host_cpu}-${host_os}"]
     )
 
+    dnl check for brew
+    AS_IF([command -v brew 2>/dev/null >/dev/null],
+	[brewboostdir=$(brew --prefix boost)],
+	[brewboostdir=""]
+    )
     dnl first we check the system location for boost libraries
     dnl this location ist chosen if boost libraries are installed with the --layout=system option
     dnl or if you install boost with RPM
     dnl AS_IF([test "x$_AX_BOOST_BASE_boost_path" != "x"],[
 
-    for _AX_BOOST_BASE_prefix_tmp in $_AX_BOOST_BASE_boost_path $(pwd)/boost-* ${HOME}/boost/boost-* /usr /usr/local /opt /opt/local $(brew --prefix boost) ; do
+    for _AX_BOOST_BASE_prefix_tmp in $_AX_BOOST_BASE_boost_path $(pwd)/boost-* ${HOME}/boost/boost-* /usr /usr/local /opt /opt/local $brewboostdir ; do
       if test -d $_AX_BOOST_BASE_prefix_tmp/include/boost ; then
         AC_MSG_CHECKING([for boostlib >= $1 ($WANT_BOOST_VERSION) includes in "$_AX_BOOST_BASE_prefix_tmp/include"])
         AS_IF([test -d "$_AX_BOOST_BASE_prefix_tmp/include/boost" && test -r "$_AX_BOOST_BASE_prefix_tmp/include/boost"],[

--- a/m4/ax_pthread.m4
+++ b/m4/ax_pthread.m4
@@ -14,20 +14,24 @@
 #   flags that are needed. (The user can also force certain compiler
 #   flags/libs to be tested by setting these environment variables.)
 #
-#   Also sets PTHREAD_CC to any special C compiler that is needed for
-#   multi-threaded programs (defaults to the value of CC otherwise). (This
-#   is necessary on AIX to use the special cc_r compiler alias.)
+#   Also sets PTHREAD_CC and PTHREAD_CXX to any special C compiler that is
+#   needed for multi-threaded programs (defaults to the value of CC
+#   respectively CXX otherwise). (This is necessary on e.g. AIX to use the
+#   special cc_r/CC_r compiler alias.)
 #
 #   NOTE: You are assumed to not only compile your program with these flags,
 #   but also to link with them as well. For example, you might link with
 #   $PTHREAD_CC $CFLAGS $PTHREAD_CFLAGS $LDFLAGS ... $PTHREAD_LIBS $LIBS
+#   $PTHREAD_CXX $CXXFLAGS $PTHREAD_CFLAGS $LDFLAGS ... $PTHREAD_LIBS $LIBS
 #
 #   If you are only building threaded programs, you may wish to use these
 #   variables in your default LIBS, CFLAGS, and CC:
 #
 #     LIBS="$PTHREAD_LIBS $LIBS"
 #     CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+#     CXXFLAGS="$CXXFLAGS $PTHREAD_CFLAGS"
 #     CC="$PTHREAD_CC"
+#     CXX="$PTHREAD_CXX"
 #
 #   In addition, if the PTHREAD_CREATE_JOINABLE thread-attribute constant
 #   has a nonstandard name, this macro defines PTHREAD_CREATE_JOINABLE to
@@ -55,6 +59,7 @@
 #
 #   Copyright (c) 2008 Steven G. Johnson <stevenj@alum.mit.edu>
 #   Copyright (c) 2011 Daniel Richard G. <skunk@iSKUNK.ORG>
+#   Copyright (c) 2019 Marc Stevens <marc.stevens@cwi.nl>
 #
 #   This program is free software: you can redistribute it and/or modify it
 #   under the terms of the GNU General Public License as published by the
@@ -82,7 +87,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 24
+#serial 31
 
 AU_ALIAS([ACX_PTHREAD], [AX_PTHREAD])
 AC_DEFUN([AX_PTHREAD], [
@@ -104,6 +109,7 @@ if test "x$PTHREAD_CFLAGS$PTHREAD_LIBS" != "x"; then
         ax_pthread_save_CFLAGS="$CFLAGS"
         ax_pthread_save_LIBS="$LIBS"
         AS_IF([test "x$PTHREAD_CC" != "x"], [CC="$PTHREAD_CC"])
+        AS_IF([test "x$PTHREAD_CXX" != "x"], [CXX="$PTHREAD_CXX"])
         CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
         LIBS="$PTHREAD_LIBS $LIBS"
         AC_MSG_CHECKING([for pthread_join using $CC $PTHREAD_CFLAGS $PTHREAD_LIBS])
@@ -123,10 +129,12 @@ fi
 # (e.g. DEC) have both -lpthread and -lpthreads, where one of the
 # libraries is broken (non-POSIX).
 
-# Create a list of thread flags to try.  Items starting with a "-" are
-# C compiler flags, and other items are library names, except for "none"
-# which indicates that we try without any flags at all, and "pthread-config"
-# which is a program returning the flags for the Pth emulation library.
+# Create a list of thread flags to try. Items with a "," contain both
+# C compiler flags (before ",") and linker flags (after ","). Other items
+# starting with a "-" are C compiler flags, and remaining items are
+# library names, except for "none" which indicates that we try without
+# any flags at all, and "pthread-config" which is a program returning
+# the flags for the Pth emulation library.
 
 ax_pthread_flags="pthreads none -Kthread -pthread -pthreads -mthreads pthread --thread-safe -mt pthread-config"
 
@@ -194,14 +202,47 @@ case $host_os in
         # that too in a future libc.)  So we'll check first for the
         # standard Solaris way of linking pthreads (-mt -lpthread).
 
-        ax_pthread_flags="-mt,pthread pthread $ax_pthread_flags"
+        ax_pthread_flags="-mt,-lpthread pthread $ax_pthread_flags"
         ;;
 esac
 
+# Are we compiling with Clang?
+
+AC_CACHE_CHECK([whether $CC is Clang],
+    [ax_cv_PTHREAD_CLANG],
+    [ax_cv_PTHREAD_CLANG=no
+     # Note that Autoconf sets GCC=yes for Clang as well as GCC
+     if test "x$GCC" = "xyes"; then
+        AC_EGREP_CPP([AX_PTHREAD_CC_IS_CLANG],
+            [/* Note: Clang 2.7 lacks __clang_[a-z]+__ */
+#            if defined(__clang__) && defined(__llvm__)
+             AX_PTHREAD_CC_IS_CLANG
+#            endif
+            ],
+            [ax_cv_PTHREAD_CLANG=yes])
+     fi
+    ])
+ax_pthread_clang="$ax_cv_PTHREAD_CLANG"
+
+
 # GCC generally uses -pthread, or -pthreads on some platforms (e.g. SPARC)
 
+# Note that for GCC and Clang -pthread generally implies -lpthread,
+# except when -nostdlib is passed.
+# This is problematic using libtool to build C++ shared libraries with pthread:
+# [1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=25460
+# [2] https://bugzilla.redhat.com/show_bug.cgi?id=661333
+# [3] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=468555
+# To solve this, first try -pthread together with -lpthread for GCC
+
 AS_IF([test "x$GCC" = "xyes"],
-      [ax_pthread_flags="-pthread -pthreads $ax_pthread_flags"])
+      [ax_pthread_flags="-pthread,-lpthread -pthread -pthreads $ax_pthread_flags"])
+
+# Clang takes -pthread (never supported any other flag), but we'll try with -lpthread first
+
+AS_IF([test "x$ax_pthread_clang" = "xyes"],
+      [ax_pthread_flags="-pthread,-lpthread -pthread"])
+
 
 # The presence of a feature test macro requesting re-entrant function
 # definitions is, on some systems, a strong hint that pthreads support is
@@ -224,101 +265,6 @@ AS_IF([test "x$ax_pthread_check_macro" = "x--"],
       [ax_pthread_check_cond=0],
       [ax_pthread_check_cond="!defined($ax_pthread_check_macro)"])
 
-# Are we compiling with Clang?
-
-AC_CACHE_CHECK([whether $CC is Clang],
-    [ax_cv_PTHREAD_CLANG],
-    [ax_cv_PTHREAD_CLANG=no
-     # Note that Autoconf sets GCC=yes for Clang as well as GCC
-     if test "x$GCC" = "xyes"; then
-        AC_EGREP_CPP([AX_PTHREAD_CC_IS_CLANG],
-            [/* Note: Clang 2.7 lacks __clang_[a-z]+__ */
-#            if defined(__clang__) && defined(__llvm__)
-             AX_PTHREAD_CC_IS_CLANG
-#            endif
-            ],
-            [ax_cv_PTHREAD_CLANG=yes])
-     fi
-    ])
-ax_pthread_clang="$ax_cv_PTHREAD_CLANG"
-
-ax_pthread_clang_warning=no
-
-# Clang needs special handling, because older versions handle the -pthread
-# option in a rather... idiosyncratic way
-
-if test "x$ax_pthread_clang" = "xyes"; then
-
-        # Clang takes -pthread; it has never supported any other flag
-
-        # (Note 1: This will need to be revisited if a system that Clang
-        # supports has POSIX threads in a separate library.  This tends not
-        # to be the way of modern systems, but it's conceivable.)
-
-        # (Note 2: On some systems, notably Darwin, -pthread is not needed
-        # to get POSIX threads support; the API is always present and
-        # active.  We could reasonably leave PTHREAD_CFLAGS empty.  But
-        # -pthread does define _REENTRANT, and while the Darwin headers
-        # ignore this macro, third-party headers might not.)
-
-        PTHREAD_CFLAGS="-pthread"
-        PTHREAD_LIBS=
-
-        ax_pthread_ok=yes
-
-        # However, older versions of Clang make a point of warning the user
-        # that, in an invocation where only linking and no compilation is
-        # taking place, the -pthread option has no effect ("argument unused
-        # during compilation").  They expect -pthread to be passed in only
-        # when source code is being compiled.
-        #
-        # Problem is, this is at odds with the way Automake and most other
-        # C build frameworks function, which is that the same flags used in
-        # compilation (CFLAGS) are also used in linking.  Many systems
-        # supported by AX_PTHREAD require exactly this for POSIX threads
-        # support, and in fact it is often not straightforward to specify a
-        # flag that is used only in the compilation phase and not in
-        # linking.  Such a scenario is extremely rare in practice.
-        #
-        # Even though use of the -pthread flag in linking would only print
-        # a warning, this can be a nuisance for well-run software projects
-        # that build with -Werror.  So if the active version of Clang has
-        # this misfeature, we search for an option to squash it.
-
-        AC_CACHE_CHECK([whether Clang needs flag to prevent "argument unused" warning when linking with -pthread],
-            [ax_cv_PTHREAD_CLANG_NO_WARN_FLAG],
-            [ax_cv_PTHREAD_CLANG_NO_WARN_FLAG=unknown
-             # Create an alternate version of $ac_link that compiles and
-             # links in two steps (.c -> .o, .o -> exe) instead of one
-             # (.c -> exe), because the warning occurs only in the second
-             # step
-             ax_pthread_save_ac_link="$ac_link"
-             ax_pthread_sed='s/conftest\.\$ac_ext/conftest.$ac_objext/g'
-             ax_pthread_link_step=`$as_echo "$ac_link" | sed "$ax_pthread_sed"`
-             ax_pthread_2step_ac_link="($ac_compile) && (echo ==== >&5) && ($ax_pthread_link_step)"
-             ax_pthread_save_CFLAGS="$CFLAGS"
-             for ax_pthread_try in '' -Qunused-arguments -Wno-unused-command-line-argument unknown; do
-                AS_IF([test "x$ax_pthread_try" = "xunknown"], [break])
-                CFLAGS="-Werror -Wunknown-warning-option $ax_pthread_try -pthread $ax_pthread_save_CFLAGS"
-                ac_link="$ax_pthread_save_ac_link"
-                AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
-                    [ac_link="$ax_pthread_2step_ac_link"
-                     AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
-                         [break])
-                    ])
-             done
-             ac_link="$ax_pthread_save_ac_link"
-             CFLAGS="$ax_pthread_save_CFLAGS"
-             AS_IF([test "x$ax_pthread_try" = "x"], [ax_pthread_try=no])
-             ax_cv_PTHREAD_CLANG_NO_WARN_FLAG="$ax_pthread_try"
-            ])
-
-        case "$ax_cv_PTHREAD_CLANG_NO_WARN_FLAG" in
-                no | unknown) ;;
-                *) PTHREAD_CFLAGS="$ax_cv_PTHREAD_CLANG_NO_WARN_FLAG $PTHREAD_CFLAGS" ;;
-        esac
-
-fi # $ax_pthread_clang = yes
 
 if test "x$ax_pthread_ok" = "xno"; then
 for ax_pthread_try_flag in $ax_pthread_flags; do
@@ -328,10 +274,10 @@ for ax_pthread_try_flag in $ax_pthread_flags; do
                 AC_MSG_CHECKING([whether pthreads work without any flags])
                 ;;
 
-                -mt,pthread)
-                AC_MSG_CHECKING([whether pthreads work with -mt -lpthread])
-                PTHREAD_CFLAGS="-mt"
-                PTHREAD_LIBS="-lpthread"
+                *,*)
+                PTHREAD_CFLAGS=`echo $ax_pthread_try_flag | sed "s/^\(.*\),\(.*\)$/\1/"`
+                PTHREAD_LIBS=`echo $ax_pthread_try_flag | sed "s/^\(.*\),\(.*\)$/\2/"`
+                AC_MSG_CHECKING([whether pthreads work with "$PTHREAD_CFLAGS" and "$PTHREAD_LIBS"])
                 ;;
 
                 -*)
@@ -371,7 +317,13 @@ for ax_pthread_try_flag in $ax_pthread_flags; do
 #                       if $ax_pthread_check_cond
 #                        error "$ax_pthread_check_macro must be defined"
 #                       endif
-                        static void routine(void *a) { a = 0; }
+                        static void *some_global = NULL;
+                        static void routine(void *a)
+                          {
+                             /* To avoid any unused-parameter or
+                                unused-but-set-parameter warning.  */
+                             some_global = a;
+                          }
                         static void *start_routine(void *a) { return a; }],
                        [pthread_t th; pthread_attr_t attr;
                         pthread_create(&th, 0, start_routine, 0);
@@ -392,6 +344,80 @@ for ax_pthread_try_flag in $ax_pthread_flags; do
         PTHREAD_CFLAGS=""
 done
 fi
+
+
+# Clang needs special handling, because older versions handle the -pthread
+# option in a rather... idiosyncratic way
+
+if test "x$ax_pthread_clang" = "xyes"; then
+
+        # Clang takes -pthread; it has never supported any other flag
+
+        # (Note 1: This will need to be revisited if a system that Clang
+        # supports has POSIX threads in a separate library.  This tends not
+        # to be the way of modern systems, but it's conceivable.)
+
+        # (Note 2: On some systems, notably Darwin, -pthread is not needed
+        # to get POSIX threads support; the API is always present and
+        # active.  We could reasonably leave PTHREAD_CFLAGS empty.  But
+        # -pthread does define _REENTRANT, and while the Darwin headers
+        # ignore this macro, third-party headers might not.)
+
+        # However, older versions of Clang make a point of warning the user
+        # that, in an invocation where only linking and no compilation is
+        # taking place, the -pthread option has no effect ("argument unused
+        # during compilation").  They expect -pthread to be passed in only
+        # when source code is being compiled.
+        #
+        # Problem is, this is at odds with the way Automake and most other
+        # C build frameworks function, which is that the same flags used in
+        # compilation (CFLAGS) are also used in linking.  Many systems
+        # supported by AX_PTHREAD require exactly this for POSIX threads
+        # support, and in fact it is often not straightforward to specify a
+        # flag that is used only in the compilation phase and not in
+        # linking.  Such a scenario is extremely rare in practice.
+        #
+        # Even though use of the -pthread flag in linking would only print
+        # a warning, this can be a nuisance for well-run software projects
+        # that build with -Werror.  So if the active version of Clang has
+        # this misfeature, we search for an option to squash it.
+
+        AC_CACHE_CHECK([whether Clang needs flag to prevent "argument unused" warning when linking with -pthread],
+            [ax_cv_PTHREAD_CLANG_NO_WARN_FLAG],
+            [ax_cv_PTHREAD_CLANG_NO_WARN_FLAG=unknown
+             # Create an alternate version of $ac_link that compiles and
+             # links in two steps (.c -> .o, .o -> exe) instead of one
+             # (.c -> exe), because the warning occurs only in the second
+             # step
+             ax_pthread_save_ac_link="$ac_link"
+             ax_pthread_sed='s/conftest\.\$ac_ext/conftest.$ac_objext/g'
+             ax_pthread_link_step=`AS_ECHO(["$ac_link"]) | sed "$ax_pthread_sed"`
+             ax_pthread_2step_ac_link="($ac_compile) && (echo ==== >&5) && ($ax_pthread_link_step)"
+             ax_pthread_save_CFLAGS="$CFLAGS"
+             for ax_pthread_try in '' -Qunused-arguments -Wno-unused-command-line-argument unknown; do
+                AS_IF([test "x$ax_pthread_try" = "xunknown"], [break])
+                CFLAGS="-Werror -Wunknown-warning-option $ax_pthread_try -pthread $ax_pthread_save_CFLAGS"
+                ac_link="$ax_pthread_save_ac_link"
+                AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
+                    [ac_link="$ax_pthread_2step_ac_link"
+                     AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
+                         [break])
+                    ])
+             done
+             ac_link="$ax_pthread_save_ac_link"
+             CFLAGS="$ax_pthread_save_CFLAGS"
+             AS_IF([test "x$ax_pthread_try" = "x"], [ax_pthread_try=no])
+             ax_cv_PTHREAD_CLANG_NO_WARN_FLAG="$ax_pthread_try"
+            ])
+
+        case "$ax_cv_PTHREAD_CLANG_NO_WARN_FLAG" in
+                no | unknown) ;;
+                *) PTHREAD_CFLAGS="$ax_cv_PTHREAD_CLANG_NO_WARN_FLAG $PTHREAD_CFLAGS" ;;
+        esac
+
+fi # $ax_pthread_clang = yes
+
+
 
 # Various other checks:
 if test "x$ax_pthread_ok" = "xyes"; then
@@ -438,7 +464,8 @@ if test "x$ax_pthread_ok" = "xyes"; then
         AC_CACHE_CHECK([for PTHREAD_PRIO_INHERIT],
             [ax_cv_PTHREAD_PRIO_INHERIT],
             [AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <pthread.h>]],
-                                             [[int i = PTHREAD_PRIO_INHERIT;]])],
+                                             [[int i = PTHREAD_PRIO_INHERIT;
+                                               return i;]])],
                             [ax_cv_PTHREAD_PRIO_INHERIT=yes],
                             [ax_cv_PTHREAD_PRIO_INHERIT=no])
             ])
@@ -460,18 +487,28 @@ if test "x$ax_pthread_ok" = "xyes"; then
                     [#handle absolute path differently from PATH based program lookup
                      AS_CASE(["x$CC"],
                          [x/*],
-                         [AS_IF([AS_EXECUTABLE_P([${CC}_r])],[PTHREAD_CC="${CC}_r"])],
-                         [AC_CHECK_PROGS([PTHREAD_CC],[${CC}_r],[$CC])])])
+                         [
+			   AS_IF([AS_EXECUTABLE_P([${CC}_r])],[PTHREAD_CC="${CC}_r"])
+			   AS_IF([test "x${CXX}" != "x"], [AS_IF([AS_EXECUTABLE_P([${CXX}_r])],[PTHREAD_CXX="${CXX}_r"])])
+			 ],
+                         [
+			   AC_CHECK_PROGS([PTHREAD_CC],[${CC}_r],[$CC])
+			   AS_IF([test "x${CXX}" != "x"], [AC_CHECK_PROGS([PTHREAD_CXX],[${CXX}_r],[$CXX])])
+			 ]
+                     )
+                    ])
                 ;;
             esac
         fi
 fi
 
 test -n "$PTHREAD_CC" || PTHREAD_CC="$CC"
+test -n "$PTHREAD_CXX" || PTHREAD_CXX="$CXX"
 
 AC_SUBST([PTHREAD_LIBS])
 AC_SUBST([PTHREAD_CFLAGS])
 AC_SUBST([PTHREAD_CC])
+AC_SUBST([PTHREAD_CXX])
 
 # Finally, execute ACTION-IF-FOUND/ACTION-IF-NOT-FOUND:
 if test "x$ax_pthread_ok" = "xyes"; then

--- a/scripts/cpc.sh
+++ b/scripts/cpc.sh
@@ -50,10 +50,22 @@ if [ "$3" = "" ] ; then
 		$BIRTHDAYSEARCH --inputfile1 "$file1" --inputfile2 "$file2" --hybridbits 0 --pathtyperange 2 --maxblocks 9 --maxmemory 100 --threads $CPUS --cuda_enable
 	fi
 	notify "Birthday search completed."
+
+	PREFIX1=file1.bin
+	PREFIX2=file2.bin
+	COLL1=`ls data/birthdayblock1_*.bin | head -n1`
+	if [ ! -f $COLL1 ]; then
+		echo "Birthday block file $COLL1 not found"
+		exit 1
+	fi
+	COLL2=`echo $COLL1 | sed "s/birthdayblock1/birthdayblock2/"`
+
+	cat $PREFIX1 $COLL1 > file1_0.bin
+	cat $PREFIX2 $COLL2 > file2_0.bin
 else
 	if [ "$4" != "" ]; then
-		cp $file1 file1.bin
-		cp $file2 file2.bin
+		cp $file1 file1_0.bin
+		cp $file2 file2_0.bin
 	fi
 fi
 
@@ -63,7 +75,7 @@ function doforward {
 }
 
 function dobackward {
-	$BACKWARD -w $1 -f $1/upperpath.bin.gz -t 34 --trange 4 -a 65536 -q 128 --threads $CPUS || return 1
+	$BACKWARD -w $1 -f $1/upperpath.bin.gz -t 36 --trange 6 -a 65536 -q 128 --threads $CPUS || return 1
 	$BACKWARD -w $1 -t 29 -a 100000 --trange 8 --threads $CPUS || return 1
 	$BACKWARD -w $1 -t 20 -a 16384 --threads $CPUS || return 1
 	$BACKWARD -w $1 -t 19 -a 500000 --trange $((18-$TTT-3)) --threads $CPUS || return 1
@@ -163,8 +175,8 @@ function auto_kill
 	kill -KILL $pid &>/dev/null
 }
 
-cp file1.bin file1_0.bin
-cp file2.bin file2_0.bin
+#cp file1.bin file1_0.bin
+#cp file2.bin file2_0.bin
 let k=0
 if [ "$3" != "" ]; then
 	let k=$3

--- a/scripts/fastcpc.sh
+++ b/scripts/fastcpc.sh
@@ -1,0 +1,325 @@
+#!/bin/bash
+
+PATHTYPERANGE=2
+HYBRIDBITS=0
+MAXBLOCKS=7
+MAXMEMORY=8000
+UPPERPATHCOUNT=2000000
+TTT=12
+
+VERBOSE_LOG=2
+
+BIRTHDAY_CONTROLLER_NODES=1
+BIRTHDAY_GENERATOR_NODES=0
+
+BIRTHDAY_LOCAL_CONFIG="--cuda_enable --saveloadwait 1"
+BIRTHDAY_GLOBAL_CONFIG="--pathtyperange $PATHTYPERANGE --hybridbits $HYBRIDBITS --maxblocks $MAXBLOCKS --maxmemory $MAXMEMORY"
+
+# this is the workdir in which the script was called
+WORKDIR=`pwd`
+
+# this is the directory of the script itself within 'hashclash/scripts/'
+SCRIPTDIR=$(dirname $0)
+
+# from SCRIPTDIR we derive the 'hashclash/bin' directory where all hashclash binaries reside
+HASHCLASHBIN=$SCRIPTDIR/../bin
+
+function logthis
+{
+	loglvl=$1
+	logstep=$2
+	shift 2
+	if [ "$CPCTIMESTAMP" = "" ]; then
+		CPCTIMESTAMP=`date +%s`
+		DATESTR=`date -Is`
+	else
+		DATESTR=+$(( `date +%s` - $CPCTIMESTAMP ))s
+	fi
+	if [ $loglvl -le $VERBOSE_LOG ]; then
+		echo "[LVL$loglvl][$DATESTR][$logstep] $*"
+	fi
+}
+
+function precompute
+{
+	PRECOMPDIR=precompute/diff$1
+	UPPERPATHFILE=$PRECOMPDIR/paths$(($TTT+4))_0of1_$UPPERPATHCOUNT.bin.gz
+	if [ ! -f $UPPERPATHFILE ]; then
+		logthis 1 "PRECOMPUTE $1" "START"
+		TIMESTART=`date +%s`
+		mkdir -p $PRECOMPDIR 2>/dev/null
+		for f in md5diffpathbackward.cfg md5diffpathforward.cfg md5diffpathhelper.cfg; do
+			rm $f 2>/dev/null
+			cat ${f}.template > $f 2>/dev/null
+			echo "diffm11 = $1" >> $f
+			echo "workdir = $PRECOMPDIR" >> $f
+		done
+		[ ! -f $PRECOMPDIR/paths30_0of1.bin.gz ] && ( $HASHCLASHBIN/md5_diffpathbackward -n -t 34 --trange 4 -a 65536 -q 128 > $PRECOMPDIR/backward.log 2>&1 )
+		if [ ! -f $PRECOMPDIR/paths21_0of1.bin.gz ]; then
+			for ((x=40; ; ++x)); do
+				$HASHCLASHBIN/md5_diffpathbackward -t 29 --trange 8 --maxQ26upcond $x >> $PRECOMPDIR/backward.log 2>&1
+				if [ -f $PRECOMPDIR/paths21_0of1.bin.gz ]; then
+					logthis 2 "PRECOMPUTE $1" "Using maxQ26upcond = $x"
+					break
+				fi
+			done
+		fi
+		[ ! -f $PRECOMPDIR/paths20_0of1.bin.gz ] && $HASHCLASHBIN/md5_diffpathbackward -t 20 -q 1 -a 16384 >> $PRECOMPDIR/backward.log 2>&1
+		[ ! -f $PRECOMPDIR/paths$(($TTT+5))_0of1.bin.gz ] && $HASHCLASHBIN/md5_diffpathbackward -t 19 --trange $((18-$TTT-4)) >> $PRECOMPDIR/backward.log 2>&1
+		if $HASHCLASHBIN/md5_diffpathbackward -t $(($TTT+4)) -a $UPPERPATHCOUNT >> $PRECOMPDIR/backward.log 2>&1 ; then
+			mv $PRECOMPDIR/paths$(($TTT+4))_0of1.bin.gz $UPPERPATHFILE
+			TIMELAPSED=$((`date +%s` - $TIMESTART))
+			logthis 1 "PRECOMPUTE $1" "DONE: $TIMELAPSED s"
+		else
+			TIMELAPSED=$((`date +%s` - $TIMESTART))
+			logthis 1 "PRECOMPUTE $1" "FAILED: $TIMELAPSED s"
+			rm $PRECOMPDIR/paths*.bin.gz
+		fi
+	fi
+	if $2 ; then
+		PRECOMPDIR2=precompute/diff-$1
+		if [ ! -f $PRECOMPDIR2/paths$((TTT+4))_0of1_$UPPERPATHCOUNT.bin.gz ]; then
+			logthis 1 "PRECOMPUTE -$1" "NEGATE FROM $1"
+			rm -r $PRECOMPDIR2 2>/dev/null
+			mkdir $PRECOMPDIR2
+			$HASHCLASHBIN/md5_diffpathhelper --negatepaths --inputfile1 $PRECOMPDIR/paths$((TTT+4))_0of1_$UPPERPATHCOUNT.bin.gz --outputfile1 $PRECOMPDIR2/paths$((TTT+4))_0of1_$UPPERPATHCOUNT.bin.gz > $PRECOMPDIR2/negate.log 2>&1
+		fi
+	fi
+}
+
+function allprecompute
+{
+	logthis 0 "PRECOMPUTE" "Precomputing missing precomputation files"
+	for ((diff=1; diff < 32; ++diff)); do
+		precompute $diff true
+	done
+	precompute $diff false
+}
+
+function asyncstartprocessonhost
+{
+	nodeidx=$1
+	logfile=$2
+	shift 2
+
+	logthis 2 "START PROCESS ON NODE$nodeidx" "$* > $logfile"
+
+	if [ $nodeidx -gt 0 ]; then
+		echo "To run this script on multiple nodes you need to manually implement job distribution and kill in this script."
+		abort 1
+	fi
+
+	# Simply run the command on the local machine
+	$* > $logfile 2>&1 &
+}
+function asynckillprocessonhosts
+{
+	# Run this command on all hosts: killall $1 (NOT IMPLEMENTED)
+	
+	# Simply run the kill command on the local machine
+	logthis 2 "KILL PROCESS ON NODE0" "$1"
+	killall $1
+}
+
+function asyncstartbirthdaysearch
+{
+	mkdir birthday_workdir 2>/dev/null
+	rm birthday_workdir/* 2>/dev/null
+
+	logthis 1 "DISTRIBUTING BIRTHDAY" "$HASHCLASHBIN/md5_birthdaysearch -w birthday_workdir -i <nodeidx> -m $BIRTHDAY_CONTROLLER_NODES $BIRTHDAY_LOCAL_CONFIG $BIRTHDAY_GLOBAL_CONFIG $*"
+	
+	# example single process on a single machine (uses all CUDA devices and all threads)
+	for (( i=0 ; i < $BIRTHDAY_CONTROLLER_NODES ; ++i )); do
+		asyncstartprocessonhost $i birthday_workdir/birthday_con_node$i.log $HASHCLASHBIN/md5_birthdaysearch -w birthday_workdir -i $i -m $BIRTHDAY_CONTROLLER_NODES $BIRTHDAY_LOCAL_CONFIG $BIRTHDAY_GLOBAL_CONFIG $*
+	done
+	for (( j=0 ; j < $BIRTHDAY_GENERATOR_NODES ; ++j )); do
+		let i=$j+$BIRTHDAY_CONTROLLER_NODES
+		asyncstartprocessonhost $i birthday_workdir/birthday_gen_node$i.log $HASHCLASHBIN/md5_birthdaysearch -w birthday_workdir --generatormode -m $BIRTHDAY_CONTROLLER_NODES $BIRTHDAY_LOCAL_CONFIG $BIRTHDAY_GLOBAL_CONFIG $*
+	done
+}
+function asyncstopbirthdaysearch
+{
+	asynckillprocessonhosts md5_birthdaysearch
+}
+
+if [ "$1" = "" ]; then
+	echo "Usage: $0 <prefixfile1> <prefixfile2>"
+	exit 0
+fi
+if [ "$1" = "__birthday" ]; then
+	shift 1
+	startbirthdaysearch $*
+	exit 0
+fi
+if [ "$1" = "__forwardconnect" ]; then
+	shift 1
+	startforwardconnect $*
+	exit 0
+fi
+
+PREFIXFILE1=$1
+PREFIXFILE2=$2
+
+if [ ! -f $PREFIXFILE1 ]; then
+	echo "Cannot find $PREFIXFILE1"
+	exit 1
+fi
+if [ ! -f $PREFIXFILE2 ]; then
+	echo "Cannot find $PREFIXFILE2"
+	exit 1
+fi
+
+logthis 0 "START CHOSEN-PREFIX COLLISION ATTACK"
+logthis 0 "WRITING CONFIGURATION FILES"
+
+cat <<EOF > md5diffpathbackward.cfg.template
+autobalance = 4000000
+estimate = 4
+fillfraction = 1
+maxsdrs = 1
+condtend = 35
+EOF
+
+cat <<EOF > md5diffpathforward.cfg.template
+autobalance = 3000000
+estimate = 1.3
+fillfraction = 1
+maxsdrs = 128
+minQ456tunnel = 18
+minQ91011tunnel = 18
+EOF
+
+cat <<EOF > md5diffpathconnect.cfg.template
+Qcondstart = 21
+waitinputfile = true
+# Ignore low quality full paths
+mintunnel=35
+EOF
+
+allprecompute
+
+function kill_all_processes
+{
+asynckillprocessonhosts md5_birthdaysearch
+asynckillprocessonhosts md5_diffpathhelper
+asynckillprocessonhosts md5_diffpathconnect
+asynckillprocessonhosts md5_diffpathforward
+}
+kill_all_processes
+trap kill_all_processes EXIT
+
+logthis 0 "START BIRTHDAY" "..."
+TIMESTART=`date +%s`
+
+asyncstartbirthdaysearch --inputfile1 $PREFIXFILE1 --inputfile2 $PREFIXFILE2
+
+while true; do
+	sleep 1
+	FILE1=`ls birthday_workdir/birthdayblock1_*.bin 2>/dev/null| head -n1`
+	if [ "$FILE1" = "" ]; then continue; fi
+	FILE2=`echo $FILE1 | sed "s/birthdayblock1/birthdayblock2/"`
+	if [ -f "$FILE1" -a -f "$FILE2" ]; then
+		TIMELAPSED=$((`date +%s` - $TIMESTART))
+		logthis 0 "BIRTHDAY DONE" "FINISHED: $TIMELAPSED s"
+		break
+	fi
+done
+
+asyncstopbirthdaysearch
+
+cat file1.bin $FILE1 > file1_0.bin
+cat file2.bin $FILE2 > file2_0.bin
+
+for (( i=0; ; ++i)); do
+	if [ $i -eq $MAXBLOCKS ]; then
+		logthis 0 "NC-BLOCK $i" "Error: exceeded maxblocks ?!?!?"
+		exit 1
+	fi
+
+	logthis 0 "NC-BLOCK $i" "Prepare near-collision files"
+	TIMESTART=`date +%s`
+	
+	mkdir workdir$i 2>/dev/null
+	rm workdir$i/* 2>/dev/null
+	
+	$HASHCLASHBIN/md5_diffpathhelper -w workdir$i --startnearcollision --pathtyperange $PATHTYPERANGE --inputfile1 file1_$i.bin --inputfile2 file2_$i.bin > workdir$i/snc.log 2>&1
+	cp *.cfg workdir$i/
+
+	DIFF=`grep diffm11 md5diffpathhelper.cfg | cut -d= -f2 | tr -d ' '`
+	UPPERPATH=precompute/diff$DIFF/paths$(($TTT+4))_0of1_$UPPERPATHCOUNT.bin.gz
+	logthis 2 "NC-BLOCK $i" "DIFF=$DIFF UPPERPATH=$UPPERPATH"
+	if [ ! -f $UPPERPATH ]; then
+		echo "Error: Precomputed upperpath file does not exist:\n $UPPERPATH"
+		exit 1
+	fi
+
+	logthis 0 "NC-BLOCK $i" "Starting connect process in background ..."
+	HALFTHREADS=$((`nproc`/2))
+	logthis 2 "NC-BLOCK $i" "Running command: $HASHCLASHBIN/md5_diffpathconnect --threads $HALFTHREADS -w workdir$i -t $TTT --inputfilelow workdir$i/paths$(($TTT-1))_0of1.bin.gz.done --inputfilehigh $UPPERPATH > workdir$i/connect.log &"
+	$HASHCLASHBIN/md5_diffpathconnect --threads $HALFTHREADS -w workdir$i -t $TTT --inputfilelow workdir$i/paths$(($TTT-1))_0of1.bin.gz.done --inputfilehigh $UPPERPATH > workdir$i/connect.log 2>&1 &
+
+	logthis 0 "NC-BLOCK $i" "Forward phase ..."
+	logthis 2 "NC-BLOCK $i" "Running command: $HASHCLASHBIN/md5_diffpathforward -w workdir$i -f workdir$i/lowerpath.bin.gz --normalt01 -t 1 --trange $(($TTT-2)) > workdir$i/forward.log"
+	$HASHCLASHBIN/md5_diffpathforward -w workdir$i -f workdir$i/lowerpath.bin.gz --normalt01 -t 1 --trange $(($TTT-2)) > workdir$i/forward.log 2>&1
+	mv workdir$i/paths$(($TTT-1))_0of1.bin.gz workdir$i/paths$(($TTT-1))_0of1.bin.gz.done
+
+	logthis 0 "NC-BLOCK $i" "Wait for full differential paths from connect"
+	while [ ! -f workdir$i/bestpaths.bin.gz ]; do
+		sleep 1
+	done
+	
+	PATHQUALITY=`cat workdir$i/connect.log | grep "tottunnel" | tail -n1 | grep -o "tottunnel=[0-9]*, totcond=[0-9]*"`
+	cp workdir$i/bestpaths.bin.gz workdir$i/latest_bestpaths.bin.gz
+	logthis 0 "NC-BLOCK $i" "Starting collision finding: $PATHQUALITY"
+	$HASHCLASHBIN/md5_diffpathhelper -w workdir$i --combinepaths --outputfile1 workdir$i/collfindpaths.bin.gz --inputfile1 workdir$i/latest_bestpaths.bin.gz --inputfile2 workdir$i/upperpath.bin.gz >> workdir$i/collfindpath.log 2>&1
+	$HASHCLASHBIN/md5_diffpathhelper -w workdir$i --inputfile1 workdir$i/collfindpaths.bin.gz --findcollision --threads $HALFTHREADS >> workdir$i/collfind.log 2>&1 &
+	lastw=0
+	for (( w = 0; ; ++w )); do
+		sleep 1
+		if [ $w -gt 1200 ]; then
+			logthis 0 "NC-BLOCK $i" "Time-out! Aborting ..."
+			killall md5_diffpathconnect
+			killall md5_diffpathhelper
+			exit 1
+		fi
+		if [ `ls workdir$i/coll1_* 2>/dev/null | wc -l` -ne 0 ]; then
+			logthis 0 "NC-BLOCK $i" "Collision found"
+			killall md5_diffpathconnect
+			killall md5_diffpathhelper
+			break
+		fi
+		if [ $(($w - $lastw)) -ge 10 ]; then
+		if [ workdir$i/bestpaths.bin.gz -nt workdir$i/latest_bestpaths.bin.gz ]; then
+			lastw=$w
+			PATHQUALITY=`cat workdir$i/connect.log | grep "tottunnel" | tail -n1 | grep -o "tottunnel=[0-9]*, totcond=[0-9]*"`
+			cp workdir$i/bestpaths.bin.gz workdir$i/latest_bestpaths.bin.gz
+			JOIN="-j workdir$i/latest_bestpaths.bin.gz"
+			for f in workdir$i/bestpaths_t[789]* workdir$i/bestpaths_t[456]* ; do
+				if [ -f $f ]; then
+					JOIN="$JOIN -j $f"
+				fi
+			done
+			$HASHCLASHBIN/md5_diffpathhelper -w workdir$i --outputfile1 workdir$i/joint_bestpaths.bin.gz $JOIN >> workdir$i/join.log 2>&1
+			$HASHCLASHBIN/md5_diffpathhelper -w workdir$i --combinepaths --outputfile1 workdir$i/collfindpaths.bin.gz --inputfile1 workdir$i/joint_bestpaths.bin.gz --inputfile2 workdir$i/upperpath.bin.gz >> workdir$i/collfindpath.log 2>&1
+			killall md5_diffpathhelper
+			logthis 0 "NC-BLOCK $i" "Starting collision finding: $PATHQUALITY"
+			$HASHCLASHBIN/md5_diffpathhelper -w workdir$i --inputfile1 workdir$i/collfindpaths.bin.gz --findcollision --threads $HALFTHREADS >> workdir$i/collfind.log 2>&1 &
+		fi fi
+	done
+	
+	TIMELAPSED=$((`date +%s` - $TIMESTART))
+	logthis 0 "NC-BLOCK $i" "FINISHED: $TIMELAPSED s"
+	
+	COLLFILE1=`ls workdir$i/coll1_* | head -n1`
+	COLLFILE2=`echo $COLLFILE1 | sed "s/coll1_/coll2_/"`
+	OUTFILE1=file1_$(($i+1)).bin
+	OUTFILE2=file2_$(($i+1)).bin
+
+	cat file1_$i.bin $COLLFILE1 > $OUTFILE1
+	cat file2_$i.bin $COLLFILE2 > $OUTFILE2
+
+	if [ `cat $OUTFILE1 | md5sum | cut -d' ' -f1` = `cat $OUTFILE2 | md5sum | cut -d' ' -f1` ]; then
+		logthis 0 "FINISHED" "Found collision: $OUTFILE1 $OUTFILE2"
+		exit 0
+	fi
+done

--- a/scripts/fastcpc.sh
+++ b/scripts/fastcpc.sh
@@ -7,6 +7,21 @@ MAXMEMORY=8000
 UPPERPATHCOUNT=1000000
 TTT=12
 
+# Block timeout: Once a near-collision block lasts more than this number of second
+#                the whole attack is aborted
+# A lower value means less time lost once a near-collision block gets 'stuck',
+# but also implies a lower probability of success.
+#
+# Default value is for CPU i7-11800H @ 2.30GHz (8 cores / 16 threads): 2000s
+# To fine-tune BLOCK_TIMEOUT for a particular machine use the following procedure:
+#   1) set BLOCK_TIMEOUT to 3600 or larger
+#   2) run 20 attempts and save logs:
+#      $> for ((i=0; i<20; ++i)); do ./fastcpc.sh ../README.md ../LICENSE.txt > cpc$i.log 2>&1; done
+#   3) Parse logs for near-collision block durations:
+#      $> grep "NC-BLOCK.*FINISHED" cpc*/*.log | cut -d: -f3 | cut -ds -f1 | sort -g
+#   4) Choose appropriate cut-off timeout at the end
+BLOCK_TIMEOUT=2000
+
 VERBOSE_LOG=2
 
 BIRTHDAY_CONTROLLER_NODES=1
@@ -273,7 +288,7 @@ for (( i=0; ; ++i)); do
 	while [ ! -f workdir$i/bestpaths.bin.gz ]; do
 		sleep 1
 		let w=w+1
-		if [ $w -gt 1200 ]; then
+		if [ $w -gt ${BLOCK_TIMEOUT} ]; then
 			logthis 0 "NC-BLOCK $i" "Time-out! Aborting ..."
 			killall md5_diffpathconnect
 			exit 1
@@ -288,7 +303,7 @@ for (( i=0; ; ++i)); do
 	let lastw=0
 	for (( ; ; ++w )); do
 		sleep 1
-		if [ $w -gt 1200 ]; then
+		if [ $w -gt ${BLOCK_TIMEOUT} ]; then
 			logthis 0 "NC-BLOCK $i" "Time-out! Aborting ..."
 			killall md5_diffpathconnect
 			killall md5_diffpathhelper

--- a/src/md5backward/dostep.cpp
+++ b/src/md5backward/dostep.cpp
@@ -63,7 +63,7 @@ inline std::string pathsstring(const std::string& basepath, unsigned modi, unsig
 
 
 progress_display* dostep_progress = 0;
-unsigned dostep_index = 0;
+volatile unsigned dostep_index = 0;
 struct dostep_thread {
 	dostep_thread(vector<differentialpath>& in, path_container_autobalance& out)
 		: pathsin(in), container(out)   

--- a/src/md5backward/dostep.cpp
+++ b/src/md5backward/dostep.cpp
@@ -75,17 +75,21 @@ struct dostep_thread {
 		try {
 			while (true) {
 				mut.lock();
+
 				unsigned i = dostep_index;
-				unsigned iend = i + (unsigned(pathsin.size() - dostep_index)>>4);
-				if (iend > i+4) iend = i+4;
-				if (iend == i && i < pathsin.size())
-					iend = i+1;
-				if (iend != i)
-					(*dostep_progress) += iend-i;
+				if (i >= pathsin.size())
+				{
+					mut.unlock();
+					break;
+				}
+				unsigned cnt = std::max<unsigned>(1, std::min<unsigned>(16, (pathsin.size() - i)/128 ));
+				unsigned iend = i + cnt;
+
+				if (cnt != 0)
+					(*dostep_progress) += cnt;
 				dostep_index = iend;
 				mut.unlock();
-				if (i >= pathsin.size())
-					break;
+
 				for (; i < iend; ++i)
 					worker.md5_backward_differential_step(pathsin[i], container);
 			}

--- a/src/md5backward/dostep.cpp
+++ b/src/md5backward/dostep.cpp
@@ -34,6 +34,7 @@
 #include <hashclash/rng.hpp>
 #include <hashclash/differentialpath.hpp>
 #include <hashclash/progress_display.hpp>
+#include <hashclash/timer.hpp>
 
 #include "main.hpp"
 
@@ -138,12 +139,13 @@ void dostep(path_container_autobalance& container, bool savetocache)
 		{
 			try {
 				std::string filename = pathsstring("paths" + boost::lexical_cast<std::string>(t+1), k, modn);
+				hashclash::timer loadtime(true);
 				cout << "Loading " << filename << "..." << flush;
 				load_gz(pathstmp, filename, binary_archive);
 				random_permutation(pathstmp);
 				for (unsigned j = modi; j < pathstmp.size(); j += modn)
 					pathsin.push_back(pathstmp[j]);
-				cout << "done: " << pathstmp.size() << " (work:" << pathsin.size() << ")." << endl;
+				cout << "done: " << pathstmp.size() << " (work:" << pathsin.size() << "). (" << loadtime.time() << "s)" << endl;
 			} catch(...) {
 				cout << "failed." << endl;
 			}
@@ -151,24 +153,26 @@ void dostep(path_container_autobalance& container, bool savetocache)
 	} else {
 		bool failed = false;
 		try {
+			hashclash::timer loadtime(true);
 			cout << "Loading " << container.inputfile << "..." << flush;
 			load_gz(pathstmp, binary_archive, container.inputfile);
 			random_permutation(pathstmp);
 			for (unsigned j = modi; j < pathstmp.size(); j += modn)
 				pathsin.push_back(pathstmp[j]);
-			cout << "done: " << pathsin.size() << "." << endl;
+			cout << "done: " << pathsin.size() << ". (" << loadtime.time() << "s)" << endl;
 		} catch(...) {
 			failed = true;
 			cout << "failed." << endl;
 		}
 		if (failed) {
 			try {
+				hashclash::timer loadtime(true);
 				cout << "Loading (text) " << container.inputfile << "..." << flush;
 				load_gz(pathstmp, text_archive, container.inputfile);
 				random_permutation(pathstmp);
 				for (unsigned j = modi; j < pathstmp.size(); j += modn)
 					pathsin.push_back(pathstmp[j]);
-				cout << "done: " << pathsin.size() << "." << endl;
+				cout << "done: " << pathsin.size() << ". (" << loadtime.time() << "s)" << endl;
 			} catch(...) {
 				cout << "failed." << endl;
 			}
@@ -205,10 +209,11 @@ void dostep(path_container_autobalance& container, bool savetocache)
 	else
 		throw std::runtime_error("No valid differential paths found!");
 	std::string filenameout = pathsstring("paths" + boost::lexical_cast<std::string>(t), modi, modn);
+	hashclash::timer savetime(true);
 	cout << "Saving " << pathsout.size() << " paths..." << flush;
 	if (savetocache)
 		pathsout.swap(pathscache);
 	else
 		save_gz(pathsout, filenameout, binary_archive);
-	cout << "done." << endl;
+	cout << "done. (" << savetime.time() << "s)" << endl;
 }

--- a/src/md5backward/main.hpp
+++ b/src/md5backward/main.hpp
@@ -163,7 +163,7 @@ public:
 
 		if (!noverify)
 		{
-			if (!test_path_fast(path, m_diff))
+			if (!test_path_fast(path, m_diff, t-3, t+1))
 			{
 				mut.lock();
 				++verified;

--- a/src/md5birthdaysearch/birthday.cpp
+++ b/src/md5birthdaysearch/birthday.cpp
@@ -931,8 +931,8 @@ void birthday(birthday_parameters& parameters)
 		std::cout << "Found " << cuda_dev_cnt << " CUDA devices." << std::endl;
 	}
 	// if possible save 1 cpucore for better cuda latency
-	if (parameters.threads > 1 && cuda_dev_cnt > 0 && parameters.threads == boost::thread::hardware_concurrency())
-		--parameters.threads;
+	if (parameters.threads > cuda_dev_cnt)// && parameters.threads == boost::thread::hardware_concurrency())
+		parameters.threads -= cuda_dev_cnt;
 #endif
 
 	boost::thread_group threads;

--- a/src/md5birthdaysearch/birthday.cpp
+++ b/src/md5birthdaysearch/birthday.cpp
@@ -55,6 +55,7 @@ unsigned maxblocks = 64;
 bool memhardlimit = false;
 unsigned parameterspathtyperange = 0;
 unsigned procmodn = 0, procmodi = 0;
+bool generatormode = false;
 vector< pair<uint32,uint32> > singleblockdata;
 /**/
 
@@ -448,9 +449,9 @@ void distribute_trail(const trail_type& newtrail)
 	totwork += newtrail.len;
 	totworkallproc += newtrail.len;
 	uint32 procindex = newtrail.end[1] % procmodn;
-	if (procindex == procmodi) {
+	if (procindex == procmodi && !generatormode)
 		main_storage.insert_trail(newtrail);
-	} else
+	else
 		trail_distribution[procindex].push_back(newtrail);
 }
 
@@ -794,6 +795,8 @@ void birthday(birthday_parameters& parameters)
 {
 	procmodn = parameters.modn;
 	procmodi = parameters.modi;
+	generatormode = parameters.generatormode;
+
 	trail_distribution.resize(procmodn);
 
 	// add the modi parameter to the seed
@@ -937,8 +940,10 @@ void birthday(birthday_parameters& parameters)
 	while (!quit)
 	{
 		boost::this_thread::sleep(boost::posix_time::seconds(10));
-		if (procmodn > 1) {
-			if (save_timer.time() > 60) {
+		if (procmodn > 1 || generatormode)
+		{
+			if (save_timer.time() > 60)
+			{
 				load_save_trails();
 				save_timer.start();
 			} //else load_save_trails(false);

--- a/src/md5birthdaysearch/birthday.cpp
+++ b/src/md5birthdaysearch/birthday.cpp
@@ -427,13 +427,12 @@ void find_collision(const trail_type& trail1, const trail_type& trail2)
 		cout << oc2 << " " << oa2 << " " << ob2 << endl;
 #if 1
 		quit = true;
-#else
 		string filename1 = workdir + "/birthdayblock1_" + boost::lexical_cast<string>(v)+"_" + boost::lexical_cast<string>(w)+".bin";
 		string filename2 = workdir + "/birthdayblock2_" + boost::lexical_cast<string>(v)+"_" + boost::lexical_cast<string>(w)+".bin";
 		ofstream of1(filename1.c_str(), ios::binary | ios::app);
 		ofstream of2(filename2.c_str(), ios::binary | ios::app);
-		save_block(of1,msg1);
-		save_block(of2,msg2);
+		save_block(of1,lmsg1);
+		save_block(of2,lmsg2);
 		cout << "Wrote birthdaycollision block to: " << endl;
 		cout << "\t" << filename1 << endl << "\t" << filename2 << endl;
 #endif

--- a/src/md5birthdaysearch/birthday.cpp
+++ b/src/md5birthdaysearch/birthday.cpp
@@ -528,7 +528,6 @@ void load_save_trails(bool dosave = true)
 			traildata.check = 0x56139078;
 			savepart = (savepart+1) % 64;
 			for (unsigned i = 0; i < procmodn; ++i) {
-				if ( (i%64) != savepart) continue;
 				traildata.trails.clear();
 				{
 					LOCK_GLOBAL_MUTEX;
@@ -538,9 +537,11 @@ void load_save_trails(bool dosave = true)
 					try {
 						++fileserialothers[i];
 						string basefilename = workdir + "/" + boost::lexical_cast<string>(i) 
-							+ "/birthdaydata_" + boost::lexical_cast<string>(procmodi) + "_";
+							+ "/birthdaydata_" + boost::lexical_cast<string>(procmodi) + "_"
+							+ boost::lexical_cast<string>(xrng128()) + "_";
 						string tmpfilename = "/tmp/birthdaydata_" + boost::lexical_cast<string>(i) 
-							+ "_" + boost::lexical_cast<string>(procmodi) + "_";
+							+ "_" + boost::lexical_cast<string>(procmodi) + "_"
+							+ boost::lexical_cast<string>(xrng128()) + "_";
 						save(traildata, binary_archive, tmpfilename + boost::lexical_cast<string>(fileserialothers[i]) + ".tmp");
 						boost::filesystem::copy_file( tmpfilename + boost::lexical_cast<string>(fileserialothers[i]) + ".tmp",
 							basefilename + boost::lexical_cast<string>(fileserialothers[i]) + ".bin");
@@ -942,7 +943,7 @@ void birthday(birthday_parameters& parameters)
 		boost::this_thread::sleep(boost::posix_time::seconds(10));
 		if (procmodn > 1 || generatormode)
 		{
-			if (save_timer.time() > 60)
+			if (save_timer.time() > parameters.saveloadwait)
 			{
 				load_save_trails();
 				save_timer.start();

--- a/src/md5birthdaysearch/birthday_types.hpp
+++ b/src/md5birthdaysearch/birthday_types.hpp
@@ -29,13 +29,14 @@ struct birthday_parameters {
 		: inputfile1(), inputfile2()
 		, outputfile1(), outputfile2()
 		, modn(1), modi(0)
-		, logpathlength(-1), maxblocks(16)
+		, logpathlength(-1), maxblocks(16), generatormode(false)
 		, threads(1), sputhreads(0)
 		, memhardlimit(false), distribution(false), cuda_enabled(false)
 	{}
 	unsigned threads;
 	unsigned sputhreads;
 	unsigned modn, modi;
+	bool generatormode;
 	std::string inputfile1, inputfile2;
 	std::string outputfile1, outputfile2;
 	int logpathlength;

--- a/src/md5birthdaysearch/birthday_types.hpp
+++ b/src/md5birthdaysearch/birthday_types.hpp
@@ -30,7 +30,7 @@ struct birthday_parameters {
 		, outputfile1(), outputfile2()
 		, modn(1), modi(0)
 		, logpathlength(-1), maxblocks(16), generatormode(false)
-		, threads(1), sputhreads(0)
+		, threads(1), sputhreads(0), saveloadwait(60)
 		, memhardlimit(false), distribution(false), cuda_enabled(false)
 	{}
 	unsigned threads;
@@ -43,6 +43,7 @@ struct birthday_parameters {
 	unsigned maxblocks;
 	unsigned hybridbits, pathtyperange;
 	unsigned maxmemory; // in MB, this is NOT a hard limit
+	unsigned saveloadwait;
 	bool memhardlimit;
 	bool distribution;
 	bool cuda_enabled;

--- a/src/md5birthdaysearch/dostep.cpp
+++ b/src/md5birthdaysearch/dostep.cpp
@@ -201,6 +201,7 @@ int dostep(birthday_parameters& parameters)
 	// Start job with given parameters
 	birthday(parameters);
 
+/*
 	ofstream* of1 = 0;
 	ofstream* of2 = 0;
 	if (parameters.modi == 0) {
@@ -226,6 +227,7 @@ int dostep(birthday_parameters& parameters)
 	}
 	if (of1) delete of1;
 	if (of2) delete of2;
+*/
 
 	return 0;
 }

--- a/src/md5birthdaysearch/main.cpp
+++ b/src/md5birthdaysearch/main.cpp
@@ -116,6 +116,9 @@ int main(int argc, char** argv)
 			("threads"
 				, po::value<unsigned>(&parameters.threads)->default_value(0)
 				, "Number of computing threads to start.")
+			("generatormode"
+				, po::bool_switch(&parameters.generatormode)
+				, "Activate generator mode that saves ALL trails to disk for <mod> controllers to load.\n")
 			;
 
 #ifdef HAVE_CUDA

--- a/src/md5birthdaysearch/main.cpp
+++ b/src/md5birthdaysearch/main.cpp
@@ -119,6 +119,9 @@ int main(int argc, char** argv)
 			("generatormode"
 				, po::bool_switch(&parameters.generatormode)
 				, "Activate generator mode that saves ALL trails to disk for <mod> controllers to load.\n")
+			("saveloadwait"
+				, po::value<unsigned>(&parameters.saveloadwait)->default_value(60)
+				, "Number of seconds to wait between procedure calls to save/load trails")
 			;
 
 #ifdef HAVE_CUDA

--- a/src/md5birthdaysearch/simd_avx256.cpp
+++ b/src/md5birthdaysearch/simd_avx256.cpp
@@ -115,7 +115,7 @@ void simd_device_avx256::fill_trail_buffer(uint64 seed, vector<trail_type>& buf,
 			detail->s2.w[i] = detail->e2.w[i] = 0;
 		}
 	}
-	for (unsigned k = 0; k < 0x400; ++k)
+	for (unsigned k = 0; k < (1<<24); ++k)
 	{
 		birthday_step_avx256(*detail, detail->e0.v, detail->e1.v, detail->e2.v, mod);
 		simd_word_t l, t;

--- a/src/md5birthdaysearch/simd_avx256.cpp
+++ b/src/md5birthdaysearch/simd_avx256.cpp
@@ -69,7 +69,16 @@ struct simd_avx256_detail
 
 bool simd_device_avx256::init(const uint32 ihv1b[4], const uint32 ihv2b[4], const uint32 ihv2modb[4], const uint32 precomp1b[4], const uint32 precomp2b[4], const uint32 msg1b[16], const uint32 msg2b[16], uint32 hmask, uint32 dpmask, uint32 maxlen)
 {
-	detail = new simd_avx256_detail;
+	// FIX for some old GCC versions that do not deliver proper alignment
+	void* buffer;
+	if (posix_memalign(&buffer, 64, sizeof(simd_avx256_detail)) != 0)
+	{
+		perror("posix_memalign did not work!");
+		abort();
+	}
+	detail = new (buffer) simd_avx256_detail;
+	//detail = new simd_avx256_detail;
+
 	for (unsigned i = 0; i < 16; ++i)
 	{
 		detail->msg1[i] = SIMD_WTOV(msg1b[i]);

--- a/src/md5connect/dostep.cpp
+++ b/src/md5connect/dostep.cpp
@@ -61,7 +61,7 @@ inline std::string pathsstring(const std::string& basepath, unsigned modi, unsig
 
 
 progress_display* dostep_progress = 0;
-unsigned dostep_index = 0;
+volatile unsigned dostep_index = 0;
 struct dostep_thread {
 	dostep_thread(vector<differentialpath>& inlow, vector<differentialpath>& inhigh, path_container& out)
 		: pathsinlow(inlow), pathsinhigh(inhigh), container(out)   

--- a/src/md5connect/dostep.cpp
+++ b/src/md5connect/dostep.cpp
@@ -69,24 +69,39 @@ struct dostep_thread {
 	vector<differentialpath>& pathsinlow;
 	vector<differentialpath>& pathsinhigh;
 	path_container& container;
-	void operator()() {
+	void operator()()
+	{
 		md5_connect_thread* worker = new md5_connect_thread;
-		try {			
-			while (true) {
+		try
+		{
+			vector<differentialpath> buf;
+			unsigned i = xrng128() % pathsinhigh.size();
+			while (true)
+			{
+				buf.clear();
 				mut.lock();
-				unsigned i = dostep_index;
-				unsigned iend = i + (unsigned(pathsinhigh.size() - dostep_index)>>4);
-				if (iend > i+4) iend = i+4;
-				if (iend == i && i < pathsinhigh.size())
-					iend = i+1;
-				if (iend != i)
-					(*dostep_progress) += iend-i;
-				dostep_index = iend;
-				mut.unlock();
-				if (i >= pathsinhigh.size())
+				if (dostep_index >= pathsinhigh.size())
+				{
+					mut.unlock();
 					break;
-				for (; i < iend; ++i)
-					worker->md5_connect(pathsinlow, pathsinhigh[i], container);
+				}
+				unsigned cnt = std::max<unsigned>(1, std::min<unsigned>(128, (pathsinhigh.size() - dostep_index)/128 ));
+				while (buf.size() != cnt)
+				{
+					while (pathsinhigh[i].tbegin() == pathsinhigh[i].tend())
+					{
+						++i;
+						if (i == pathsinhigh.size())
+							i = 0;
+					}
+					buf.emplace_back( std::move( pathsinhigh[i] ) );
+					pathsinhigh[i].clear();
+				}
+				dostep_index += cnt;
+				(*dostep_progress) += cnt;
+				mut.unlock();
+				for (auto& ph : buf)
+					worker->md5_connect(pathsinlow, ph, container);
 			}
 		} catch (std::exception & e) { cerr << "Worker thread: caught exception:" << endl << e.what() << endl; } catch (...) {}
 		delete worker;

--- a/src/md5connect/dostep.cpp
+++ b/src/md5connect/dostep.cpp
@@ -145,10 +145,11 @@ void dostep(path_container& container)
 			}
 		}
 		try {
+			hashclash::timer loadtime(true);
 			cout << "Loading " << container.inputfilelow << "..." << flush;
 			load_gz(pathsinlow, binary_archive, container.inputfilelow);
 			sort(pathsinlow.begin(), pathsinlow.end(), diffpathlower_less());
-			cout << "done: " << pathsinlow.size() << "." << endl;
+			cout << "done: " << pathsinlow.size() << ". (" << loadtime.time() << "s)" << endl;
 		} catch(...) {
 			cout << "failed." << endl;
 		}
@@ -167,6 +168,7 @@ void dostep(path_container& container)
 	}
 	if (modn > 1) {
 		try {
+			hashclash::timer loadtime(true);
 			cout << "Loading " << container.inputfilehigh << "..." << flush;
 			vector< differentialpath > pathstmp2;
 			load_gz(pathstmp2, binary_archive, container.inputfilehigh);
@@ -174,16 +176,17 @@ void dostep(path_container& container)
 			for (unsigned j = modi; j < pathstmp2.size(); j += modn)
 				pathsinhigh.push_back( std::move(pathstmp2[j]) );
 			sort(pathsinhigh.begin(), pathsinhigh.end(), diffpathupper_less());
-			cout << "done: " << pathsinhigh.size() << "." << endl;
+			cout << "done: " << pathsinhigh.size() << ". (" << loadtime.time() << "s)" << endl;
 		} catch(...) {
 			cout << "failed." << endl;
 		}
 	} else {
 		try {
+			hashclash::timer loadtime(true);
 			cout << "Loading " << container.inputfilehigh << "..." << flush;
 			load_gz(pathsinhigh, binary_archive, container.inputfilehigh);
 			sort(pathsinhigh.begin(), pathsinhigh.end(), diffpathupper_less());
-			cout << "done: " << pathsinhigh.size() << "." << endl;
+			cout << "done: " << pathsinhigh.size() << ". (" << loadtime.time() << "s)" << endl;
 		} catch(...) {
 			cout << "failed." << endl;
 		}

--- a/src/md5connect/main.cpp
+++ b/src/md5connect/main.cpp
@@ -83,6 +83,10 @@ int main(int argc, char** argv)
 				, po::value<string>(&container.inputfilehigh)
 				, "Use specified inputfile for upper paths.")
 
+			("waitinputfile"
+				, po::bool_switch(&container.waitinputfile)
+				, "Wait until input files exist.")
+
 			("showinputpaths,s"
 				, po::bool_switch(&container.showinputpaths)
 				, "Show all input paths.\n")

--- a/src/md5connect/main.cpp
+++ b/src/md5connect/main.cpp
@@ -61,6 +61,7 @@ int main(int argc, char** argv)
 			all("Allowed options");
 
 		int bestmaxcomp;
+		unsigned mintunnel;
 		desc.add_options()
 			("help,h", "Show options.")
 			("mod,m"
@@ -113,11 +114,15 @@ int main(int argc, char** argv)
 			("maxcomplexity"
 				, po::value<int>(&bestmaxcomp)->default_value(-1000)
 				, "Maximum complexity = \n"
-				  "  #tunnels - #Qconds\n")
+				  "  #tunnels - #Qconds\n.")
+
+			("mintunnel"
+				, po::value<unsigned>(&mintunnel)->default_value(0)
+				, "Minimum number of tunnels.\n")
 
 			("threads"
 				, po::value<int>(&container.threads)->default_value(-1)
-				, "Number of worker threads")
+				, "Number of worker threads.")
 			;
 
 		msg.add_options()	
@@ -149,6 +154,7 @@ int main(int argc, char** argv)
 		}
 		po::notify(vm);
 		container.bestmaxcomp = bestmaxcomp;
+		container.bestmaxtunnel = mintunnel;
 
 		// Process program options
 		if (vm.count("help") || vm.count("tstep")==0) {

--- a/src/md5connect/main.hpp
+++ b/src/md5connect/main.hpp
@@ -179,7 +179,6 @@ public:
 	void push_back(const differentialpath& fullpath)
 	{
 		differentialpath pathback = fullpath;
-		//pathback = fullpath;
 		try {
 		cleanup(pathback);
 		} catch (std::exception& e) {
@@ -190,7 +189,6 @@ public:
 			show_path(pathback, m_diff);
 		}
 
-//		++verified;
 		if (!noverify && !test_path_fast(pathback, m_diff))
 		{
 			mut.lock();
@@ -247,6 +245,7 @@ public:
 			bestpaths.push_back(pathback);
 			if (hw(uint32(bestpaths.size()))==1) {
 				save_gz(bestpaths, workdir + "/bestpaths", binary_archive);
+				save_gz(bestpaths, workdir + "/bestpaths_t" + boost::lexical_cast<string>(tunnel) + "_c" + boost::lexical_cast<string>(cond), binary_archive);
 				cout << "Best paths: " << bestpaths.size() << endl;
 			}
 			mut.unlock();
@@ -268,6 +267,7 @@ public:
 		double p = test_path(pathback, m_diff);
 		cout << "Best path: totcompl=" << bestmaxcomp << " tottunnel=" << bestmaxtunnel << ", totcond=" << bestpathcond << ", p=" << p << endl;
 		save_gz(pathback, workdir + "/bestpath_t" + boost::lexical_cast<string>(tunnel) + "_c" + boost::lexical_cast<string>(cond), binary_archive);
+		save_gz(bestpaths, workdir + "/bestpaths_t" + boost::lexical_cast<string>(tunnel) + "_c" + boost::lexical_cast<string>(cond), binary_archive);
 		save_gz(pathback, workdir + "/bestpath_new", binary_archive);
 		save_gz(bestpaths, workdir + "/bestpaths_new", binary_archive);
 		try { boost::filesystem::rename(workdir + "/bestpath.bin.gz", workdir + "/bestpath_old.bin.gz"); } catch (...) {}
@@ -345,10 +345,10 @@ struct diffpathupper_less
 		if (_Left.path.size() < 3)
 			throw std::runtime_error("Lower differential paths of insufficient size");
 		unsigned t = _Left.tbegin() - 1;
-		uint32 LdQtp1   = _Left[t+1].diff();
-		uint32 RdQtp1   = _Right[t+1].diff();
 		if (_Left[t+1].hw() > _Right[t+1].hw()) return true;
 		if (_Left[t+1].hw() < _Right[t+1].hw()) return false;
+		uint32 LdQtp1   = _Left[t+1].diff();
+		uint32 RdQtp1   = _Right[t+1].diff();
 		for (unsigned b = 0; b < 32; ++b)
 		{
 			if ((LdQtp1 & (1<<b)) < (RdQtp1 & (1<<b)))

--- a/src/md5connect/main.hpp
+++ b/src/md5connect/main.hpp
@@ -161,7 +161,7 @@ class path_container {
 public:
 	path_container()
 		: modn(1), modi(0), inputfilelow(), inputfilehigh()
-		, t(0), noverify(false), noenhancepath(false)
+		, t(0), noverify(false), noenhancepath(false), showinputpaths(false), waitinputfile(false)
 		, verified(0), verifiedbad(0), bestpathcond(1<<20)
 		, bestmaxtunnel(0), showstats(false), bestmaxcomp(-1000), threads(1)
 	{
@@ -290,7 +290,7 @@ public:
 	unsigned modn;
 	unsigned modi;
 	std::string inputfilelow, inputfilehigh;
-	bool showinputpaths;
+	bool showinputpaths, waitinputfile;
 
 	differentialpath bestpath;
 	vector<differentialpath> bestpaths;

--- a/src/md5connect/main.hpp
+++ b/src/md5connect/main.hpp
@@ -239,7 +239,7 @@ public:
 		if (!check_path_collfind(pathback, m_diff)) 
 			return;
 
-		if (tuncompl == bestmaxcomp && tunnel == bestmaxtunnel && cond == bestpathcond) {
+		if (tuncompl == bestmaxcomp && tunnel == bestmaxtunnel && cond <= bestpathcond + 4) {
 			mut.lock();
 			++verified;
 			bestpaths.push_back(pathback);

--- a/src/md5forward/dostep.cpp
+++ b/src/md5forward/dostep.cpp
@@ -225,17 +225,21 @@ struct dostep_thread {
 		try {
 			while (true) {
 				mut.lock();
+
 				unsigned i = dostep_index;
-				unsigned iend = i + (unsigned(pathsin.size() - dostep_index)>>4);
-				if (iend > i+4) iend = i+4;
-				if (iend == i && i < pathsin.size())
-					iend = i+1;
-				if (iend != i)
-					(*dostep_progress) += iend-i;
+				if (i >= pathsin.size())
+				{
+					mut.unlock();
+					break;
+				}
+				unsigned cnt = std::max<unsigned>(1, std::min<unsigned>(16, (pathsin.size() - i)/128 ));
+				unsigned iend = i + cnt;
+
+				if (cnt != 0)
+					(*dostep_progress) += cnt;
 				dostep_index = iend;
 				mut.unlock();
-				if (i >= pathsin.size())
-					break;
+
 				for (; i < iend; ++i)
 					worker.md5_forward_differential_step(pathsin[i], container);
 			}

--- a/src/md5forward/dostep.cpp
+++ b/src/md5forward/dostep.cpp
@@ -34,6 +34,7 @@
 #include <hashclash/rng.hpp>
 #include <hashclash/differentialpath.hpp>
 #include <hashclash/progress_display.hpp>
+#include <hashclash/timer.hpp>
 
 #include "main.hpp"
 
@@ -307,12 +308,13 @@ void dostep(path_container_autobalance& container, bool savetocache)
 		{
 			try {
 				std::string filename = pathsstring("paths" + boost::lexical_cast<std::string>(t-1), k, modn);
+				hashclash::timer loadtime(true);
 				cout << "Loading " << filename << "..." << flush;
 				load_gz(pathstmp, filename, binary_archive);
 				random_permutation(pathstmp);
 				for (unsigned j = modi; j < pathstmp.size(); j += modn)
 					pathsin.push_back(pathstmp[j]);
-				cout << "done: " << pathstmp.size() << " (work:" << pathsin.size() << ")." << endl;
+				cout << "done: " << pathstmp.size() << " (work:" << pathsin.size() << "). (" << loadtime.time() << "s)" << endl;
 			} catch(...) {
 				cout << "failed." << endl;
 			}
@@ -320,24 +322,26 @@ void dostep(path_container_autobalance& container, bool savetocache)
 	} else {
 		bool failed = false;
 		try {
+			hashclash::timer loadtime(true);
 			cout << "Loading " << container.inputfile << "..." << flush;
 			load_gz(pathstmp, binary_archive, container.inputfile);
 			random_permutation(pathstmp);
 			for (unsigned j = modi; j < pathstmp.size(); j += modn)
 				pathsin.push_back(pathstmp[j]);
-			cout << "done: " << pathsin.size() << "." << endl;
+			cout << "done: " << pathsin.size() << ". (" << loadtime.time() << "s)" << endl;
 		} catch(...) {
 			failed = true;
 			cout << "failed." << endl;
 		}
 		if (failed) {
 			try {
+				hashclash::timer loadtime(true);
 				cout << "Loading (text) " << container.inputfile << "..." << flush;
 				load_gz(pathstmp, text_archive, container.inputfile);
 				random_permutation(pathstmp);
 				for (unsigned j = modi; j < pathstmp.size(); j += modn)
 					pathsin.push_back(pathstmp[j]);
-				cout << "done: " << pathsin.size() << "." << endl;
+				cout << "done: " << pathsin.size() << ". (" << loadtime.time() << "s)" << endl;
 			} catch(...) {
 				cout << "failed." << endl;
 			}
@@ -378,9 +382,10 @@ void dostep(path_container_autobalance& container, bool savetocache)
 	unsigned splitsave = container.splitsave;
 	if (splitsave <= 1)
 	{
+		hashclash::timer savetime(true);
 		std::string filenameout = pathsstring("paths" + boost::lexical_cast<std::string>(t), modi, modn);
 		save_gz(pathsout, filenameout, binary_archive);
-		cout << "done." << endl;
+		cout << "done. (" << savetime.time() << "s)" << endl;
 		return;
 	}
 	boost::thread_group mythreads;

--- a/src/md5forward/dostep.cpp
+++ b/src/md5forward/dostep.cpp
@@ -213,7 +213,7 @@ void dostep1(const path_container_autobalance& container)
 
 
 progress_display* dostep_progress = 0;
-unsigned dostep_index = 0;
+volatile unsigned dostep_index = 0;
 struct dostep_thread {
 	dostep_thread(vector<differentialpath>& in, path_container_autobalance& out)
 		: pathsin(in), container(out)   

--- a/src/md5forward/main.cpp
+++ b/src/md5forward/main.cpp
@@ -81,7 +81,11 @@ int main(int argc, char** argv)
 
 			("showinputpaths,s"
 				, po::bool_switch(&container.showinputpaths)
-				, "Show all input paths.\n")
+				, "Show all input paths.")
+
+			("splitsave"
+				, po::value<unsigned>(&container.splitsave)->default_value(1)
+				, "Split set of output paths and save into N files.\n")
 
 			("tstep,t"
 				, po::value<unsigned>(&container.t)
@@ -122,9 +126,9 @@ int main(int argc, char** argv)
 				, po::value<unsigned>(&container.ubound)->default_value(0)
 				, "Do autobalancing using target amount.")
 
-            ("fillfraction"
-                    , po::value<double>(&container.fillfraction)->default_value(1)
-                    , "Fill up to fraction of target amount\n\twith heavier paths than maxcond.")
+			("fillfraction"
+				, po::value<double>(&container.fillfraction)->default_value(1)
+				, "Fill up to fraction of target amount\n\twith heavier paths than maxcond.")
 
 			("estimate,e"
 				, po::value<double>(&container.estimatefactor)->default_value(2)
@@ -219,6 +223,7 @@ int main(int argc, char** argv)
 		if (container.modn != 1) {
 			cout << "Using set " << container.modi << " of " << container.modn << endl;
 			container.trange = 0;
+			container.splitsave = 0;
 		}
 
 		if (false == container.normalt01 && container.t <= 1) {

--- a/src/md5forward/main.cpp
+++ b/src/md5forward/main.cpp
@@ -271,6 +271,20 @@ int main(int argc, char** argv)
 		for (unsigned tt = container.t; tt < container.t+container.trange; ++tt) {
 			path_container_autobalance containertmp = container;
 			containertmp.t = tt;
+
+			if (tt == 1 && container.ubound > 0)
+			{
+				containertmp.ubound >>= 2;
+//				containertmp.maxcond = 157;
+			}
+			if (tt == 2 && container.ubound > 0)
+			{
+				containertmp.ubound >>= 1;
+//				containertmp.maxcond = 177;
+			}
+			if (tt == 3 && container.ubound > 0)
+				containertmp.ubound >>= 0;
+
 			dostep(containertmp, true);
 		}
 		container.t += container.trange;

--- a/src/md5forward/main.hpp
+++ b/src/md5forward/main.hpp
@@ -58,7 +58,7 @@ public:
 		, nafestweight(0), halfnafweight(false), minQ456tunnel(0), minQ91011tunnel(0), minQ314tunnel(0)
 		, pathsout(0), size(0), count(0), count_balanced(0)
 		, condcount(0), verified(0), verifiedbad(0), minweight(0), fillfraction(0), threads(1)
-		, uct(-4), ucb(-1), ucc('.')
+		, uct(-4), ucb(-1), ucc('.'), main_container(nullptr)
 	{
 		if (uct < -3 || uct > 64 || ucb < 0 || ucb > 32
 			|| (ucc != '0' && ucc != '1' && ucc != '^' && ucc != '!' && ucc != 'm' && ucc != '#')
@@ -76,7 +76,9 @@ public:
 
 	~path_container_autobalance() 
 	{
-		cerr << "Autobalance parameters: maxcond=" << maxcond << endl;
+		if (main_container != nullptr)
+			return;
+		cerr << "Autobalance parameters: maxcond=" << maxcond << " (ab#:" << count_balanced << ")" << endl;
 		if (!noverify)
 			cerr << "Verified: " << verifiedbad << " bad out of " << verified << endl;
 	}
@@ -89,13 +91,39 @@ public:
 		condcount.resize(maxcond+1);
 	}
 
+	void estimate_flush_main()
+	{
+		if (main_container == nullptr)
+			return;
+		boost::lock_guard<boost::mutex> lock(mut);
+		for (unsigned i = 0; i < condcount.size(); ++i)
+		{
+			if (condcount[i])
+			{
+				main_container->estimate(i, condcount[i]);
+				condcount[i] = 0;
+			}
+		}
+		size = 0;
+		maxcond = main_container->maxcond;
+	}
+
 	void estimate(unsigned cond, unsigned amount)
 	{
 		if (cond > maxcond) return;
 		if (ubound == 0) return;
-		boost::lock_guard<boost::mutex> lock(mut);
 		condcount[cond] += amount;
 		size += amount;
+
+		// if we're a helper container then frequently sync with main controller
+		if (main_container != nullptr)
+		{
+			if (size >= 1024)
+				estimate_flush_main();
+			return;
+		}
+
+		// if we're the main container then autobalance
 		unsigned uboundf = unsigned(double(ubound) * estimatefactor);
 		if (size > uboundf) {
 			unsigned newsize = 0;
@@ -195,27 +223,53 @@ public:
 		{
 			if (!test_path_fast(path, m_diff, t-3, t+1))
 			{
-				mut.lock();
 				++verifiedbad;
 				++verified;
-				mut.unlock();
 				return;
 			}
 		}
-		mut.lock();
 		if (!noverify) ++verified;
 		if (ubound == 0) {
 			pathsout[cond].push_back(path);
-			mut.unlock();
+			++size; ++count;
+			if (main_container != nullptr && size >= 1024)
+				push_back_flush_main();
 			return;
 		}
 		if (pathsout[cond].size() < ubound) {
 			pathsout[cond].push_back(path); 
-
 			++size, ++count;
-			autobalance();
+			if (main_container != nullptr && size >= 1024)
+				push_back_flush_main();
+			if (main_container == nullptr)
+				autobalance();
 		}
-		mut.unlock();
+	}
+
+	void push_back_flush_main()
+	{
+		if (main_container == nullptr)
+			return;
+		boost::lock_guard<boost::mutex> lock(mut);
+		for (unsigned i = 0; i < pathsout.size(); ++i)
+		{
+			if (i <= main_container->maxcond)
+			{
+				main_container->size += pathsout[i].size();
+				for (auto& p : pathsout[i])
+					main_container->pathsout[i].emplace_back( std::move(p) );
+			}
+			pathsout[i].clear();
+		}
+		size = 0;
+		main_container->count += count;
+		count = 0;
+		main_container->verified += verified;
+		verified = 0;
+		main_container->verifiedbad += verifiedbad;
+		verifiedbad = 0;
+		main_container->autobalance();
+		maxcond = main_container->maxcond;
 	}
 
 	void autobalance()
@@ -353,6 +407,7 @@ public:
 	int uct, ucb;
 	char ucc;
 
+	path_container_autobalance* main_container;
 };
 
 

--- a/src/md5forward/main.hpp
+++ b/src/md5forward/main.hpp
@@ -394,6 +394,8 @@ public:
 
 	unsigned modn;
 	unsigned modi;
+	unsigned splitsave;
+
 	std::string inputfile;
 	bool showinputpaths;
 	bool normalt01;

--- a/src/md5forward/main.hpp
+++ b/src/md5forward/main.hpp
@@ -193,7 +193,7 @@ public:
 		}
 		if (!noverify)
 		{
-			if (!test_path_fast(path, m_diff))
+			if (!test_path_fast(path, m_diff, t-3, t+1))
 			{
 				mut.lock();
 				++verifiedbad;

--- a/src/md5forward/main.hpp
+++ b/src/md5forward/main.hpp
@@ -157,10 +157,12 @@ public:
 				maxcond += (nafestweight>>1);
 			else
 				maxcond += nafestweight;
-		pathsout.clear();
 		pathsout.resize(maxcond + 1);
-		condcount.clear();
+		for (auto& v : pathsout)
+			v.clear();
 		condcount.resize(maxcond + 1);
+		for (auto& v : condcount)
+			v = 0;
 	}
 
 	void push_back(const differentialpath& path, unsigned cond = 0)
@@ -295,15 +297,16 @@ public:
 		}
 	}
 
-	void export_results(vector< differentialpath >& outpaths) const
+	void export_results(vector< differentialpath >& outpaths)
 	{
 		outpaths.clear();
 		outpaths.reserve(ubound);
 		for (unsigned k = 0; k < pathsout.size() && k <= maxcond; ++k)
 		{
-			unsigned index = unsigned(outpaths.size());
-			outpaths.resize(index + pathsout[k].size());
-			std::copy(pathsout[k].begin(), pathsout[k].end(), outpaths.begin()+index);
+			if (ubound > 0 && outpaths.size() + pathsout[k].size() > ubound)
+				pathsout[k].resize(ubound - outpaths.size());
+			for (auto& p : pathsout[k])
+				outpaths.emplace_back( std::move(p) );
 		}
                 unsigned hbound = unsigned(double(ubound)*fillfraction);
                 unsigned k = maxcond+1;
@@ -312,8 +315,8 @@ public:
                         unsigned length = hbound-index;
                         if (length > pathsout[k].size())
                                 length = pathsout[k].size();
-			outpaths.resize(index + length);
-                        std::copy(pathsout[k].begin(), pathsout[k].begin()+length, outpaths.begin()+index);
+			for (size_t i = 0; i < length; ++i)
+				outpaths.emplace_back( std::move(pathsout[k][i]) );
                         ++k;
                 }
 	}

--- a/src/md5forward/main.hpp
+++ b/src/md5forward/main.hpp
@@ -291,6 +291,8 @@ public:
 			} else {
 				size = newsize + pathsout[k].size();
 				maxcond = k;
+				if (size > ubound)
+					maxcond = k-1;
 			}
 			for (unsigned j = maxcond+2; j < pathsout.size(); ++j)
 				pathsout[j].clear();

--- a/src/md5helper/convert.cpp
+++ b/src/md5helper/convert.cpp
@@ -194,6 +194,71 @@ int join(parameters_type& parameters)
 	return 0;
 }
 
+int combinepaths(parameters_type& parameters)
+{
+	if (parameters.outfile1 == "")
+	{
+		cout << "No outputfile1 given!" << endl;
+		return 2;
+	}
+	if (parameters.infile1 == "")
+	{
+		cout << "No inputfile1 given!" << endl;
+		return 2;
+	}
+	if (parameters.infile2 == "") {
+		cout << "No inputfile2 given!" << endl;
+		return 2;
+	}
+	vector<differentialpath> vecpath, vecpath2;
+	differentialpath overrulepath;
+	cout << "Loading " << parameters.infile1 << "..." << flush;
+	try {
+		load_gz(vecpath, binary_archive, parameters.infile1);
+		cout << "done (loaded " << vecpath.size() << " paths)." << endl;
+	} catch (...) {
+		cout << "failed." << endl;
+		return 3;
+	}
+	if (vecpath.empty())
+		return 5;
+	cout << "Loading " << parameters.infile2 << "..." << flush;
+	try {
+		load_gz(vecpath2, binary_archive, parameters.infile2);
+		cout << "done (loaded " << vecpath2.size() << " paths)." << endl;
+		overrulepath = vecpath2.front();
+	} catch (...) {
+		cout << "failed." << endl;
+	}
+	if (vecpath2.empty())
+	{
+		try {
+			load_gz(overrulepath, binary_archive, parameters.infile2);
+			cout << "done (loaded 1 path)." << endl;
+		} catch (...) {
+			cout << "failed." << endl;
+			return 4;
+		}
+	}
+	cout << "Using this partial path to overwrite all paths in " << parameters.infile1 << ":" << endl;
+	show_path(overrulepath, parameters.m_diff);
+	for (auto& p : vecpath)
+	{
+		for (int t = overrulepath.tbegin(); t < overrulepath.tend(); ++t)
+			p[t] = overrulepath[t];
+	}
+	cout << "Saving " << vecpath.size() << " paths to " << parameters.outfile1 << "..." << flush;
+	try {
+		save_gz(vecpath, binary_archive, parameters.outfile1);
+		cout << "done." << endl;
+	} catch (...) {
+		cout << "failed." << endl;
+		return 1;
+	}
+	show_path(vecpath.front(), parameters.m_diff);
+	return 0;
+}
+
 int convert(parameters_type& parameters)
 {	
 	differentialpath path;	

--- a/src/md5helper/convert.cpp
+++ b/src/md5helper/convert.cpp
@@ -168,7 +168,17 @@ int join(parameters_type& parameters)
 			load_gz(joinvec, binary_archive, parameters.files[i]);
 			cout << "done (loaded " << joinvec.size() << " paths)." << endl;
 			for (unsigned j = 0; j < joinvec.size(); ++j)
-				vecpath.push_back(joinvec[j]);
+				vecpath.emplace_back( std::move(joinvec[j]) );
+			continue;
+		} catch (...) {
+			cout << "bad." << flush;
+		}
+		// failed to load file as vector of diffpaths, now try as (single) diffpath itself
+		joinvec.resize(1);
+		try {
+			load_gz(joinvec.front(), binary_archive, parameters.files[i]);
+			cout << "done (loaded 1 path)." << endl;
+			vecpath.emplace_back( std::move(joinvec.front()) );
 		} catch (...) {
 			cout << "failed." << endl;
 		}

--- a/src/md5helper/convert.cpp
+++ b/src/md5helper/convert.cpp
@@ -259,6 +259,56 @@ int combinepaths(parameters_type& parameters)
 	return 0;
 }
 
+int negatepaths(parameters_type& parameters)
+{
+	if (parameters.outfile1 == "")
+	{
+		cout << "No outputfile1 given!" << endl;
+		return 2;
+	}
+	if (parameters.infile1 == "")
+	{
+		cout << "No inputfile1 given!" << endl;
+		return 2;
+	}
+	vector<differentialpath> vecpath;
+	cout << "Loading " << parameters.infile1 << "..." << flush;
+	try {
+		load_gz(vecpath, binary_archive, parameters.infile1);
+		cout << "done (loaded " << vecpath.size() << " paths)." << endl;
+	} catch (...) {
+		cout << "failed." << endl;
+		return 3;
+	}
+	if (vecpath.empty())
+		return 5;
+	show_path(vecpath.front(), parameters.m_diff);
+	for (auto& p : vecpath)
+	{
+		for (int t = p.tbegin(); t < p.tend(); ++t)
+		{
+			for (unsigned b = 0; b < 32; ++b)
+			{
+				auto bc = p(t,b);
+				if (bc==bc_plus)
+					p.setbitcondition(t,b,bc_minus);
+				else if (bc==bc_minus)
+					p.setbitcondition(t,b,bc_plus);
+			}
+		}
+	}
+	cout << "Saving " << vecpath.size() << " paths to " << parameters.outfile1 << "..." << flush;
+	try {
+		save_gz(vecpath, binary_archive, parameters.outfile1);
+		cout << "done." << endl;
+	} catch (...) {
+		cout << "failed." << endl;
+		return 1;
+	}
+	show_path(vecpath.front(), parameters.m_diff);
+	return 0;
+}
+
 int convert(parameters_type& parameters)
 {	
 	differentialpath path;	

--- a/src/md5helper/convert.cpp
+++ b/src/md5helper/convert.cpp
@@ -612,43 +612,156 @@ int partialpathfromfile(parameters_type& parameters)
 		else
 			md5compress(ihv2, msg2);
 	}
-	int steps = bytes1/4;
-	cout << "In-block prefix words: " << steps << endl;
-	if ((bytes1 % 4) != 0) {
-		cout << "WARNING!: truncating by " << (bytes1-(steps*4)) << " bytes!" << endl;
+	cout << "In-block prefix bytes: " << bytes1 << endl;
+	if (bytes1 == 0)
+	{
+		return 0;
 	}
+	if (bytes1 >= 4)
+	{
+		int steps = bytes1/4;
+		cout << "In-block prefix words: " << steps << endl;
+		if ((bytes1 % 4) != 0)
+			cout << "WARNING!: truncating by " << (bytes1-(steps*4)) << " bytes!" << endl;
 
+		uint32 Q1[68] = { ihv1[0], ihv1[3], ihv1[2], ihv1[1] };
+		uint32 Q2[68] = { ihv2[0], ihv2[3], ihv2[2], ihv2[1] };
+		msg1[steps] = xrng128();
+		for (unsigned k = 0; k < 16; ++k)
+			msg2[k] = msg1[k] + parameters.m_diff[k];
+		for (int t=0; t < steps+1; ++t)
+		{
+			Q1[Qoff+t+1] = md5_step(t, Q1[Qoff+t], Q1[Qoff+t-1], Q1[Qoff+t-2], Q1[Qoff+t-3], msg1[t]);
+			Q2[Qoff+t+1] = md5_step(t, Q2[Qoff+t], Q2[Qoff+t-1], Q2[Qoff+t-2], Q2[Qoff+t-3], msg2[t]);
+		}
+		differentialpath path;
+		for (int t = -3; t <= steps+1; ++t)
+		{
+			for (unsigned b = 0; b < 32; ++b)
+			{
+				unsigned qtb1 = (Q1[Qoff+t]>>b)&1, qtb2 = (Q2[Qoff+t]>>b)&1;
+				if (qtb1 == 0 && qtb2 == 0)
+					path.setbitcondition(t,b,bc_zero);
+				else if (qtb1 == 1 && qtb2 == 1)
+					path.setbitcondition(t,b,bc_one);
+				else if (qtb1 == 0 && qtb2 == 1)
+					path.setbitcondition(t,b,bc_plus);
+				else if (qtb1 == 1 && qtb2 == 0)
+					path.setbitcondition(t,b,bc_minus);
+			}
+		}
+		path[steps+1] = naf(path[steps+1].diff());
+		cout << endl << "Parsed path:" << endl;
+		show_path(path, parameters.m_diff);
+		vector<differentialpath> vecpath;
+		vecpath.push_back(path);
+		cout << "Saving " << parameters.outfile2 << "..." << flush;
+		try {
+			save_gz(vecpath, binary_archive, parameters.outfile2);
+			cout << "done." << endl;
+		} catch (...) {
+			cout << "failed." << endl;
+			return 1;
+		}
+		return 0;
+	}
+	
+	// if bytes1 = 1,2,3 then do special effort and generate the set of all partial differential paths
+	// which guarantee the chosen prefixed bytes
+	// TODO: generalize this case for bytes1 = 4*k + 1,2,3
 	uint32 Q1[68] = { ihv1[0], ihv1[3], ihv1[2], ihv1[1] };
 	uint32 Q2[68] = { ihv2[0], ihv2[3], ihv2[2], ihv2[1] };
-	msg1[steps] = xrng128();
-	for (unsigned k = 0; k < 16; ++k)
-		msg2[k] = msg1[k] + parameters.m_diff[k];
-	for (int t=0; t < steps+1; ++t)
-	{
-		Q1[Qoff+t+1] = md5_step(t, Q1[Qoff+t], Q1[Qoff+t-1], Q1[Qoff+t-2], Q1[Qoff+t-3], msg1[t]);
-		Q2[Qoff+t+1] = md5_step(t, Q2[Qoff+t], Q2[Qoff+t-1], Q2[Qoff+t-2], Q2[Qoff+t-3], msg2[t]);
-	}
+	uint32 mask = (~uint32(0)) << (bytes1*8);
+	msg1[0] &= ~mask;
+	uint32 val = 0;
+	uint32 Q10 = ~uint32(0), Q11 = 0;
+	uint32 Q20 = ~uint32(0), Q21 = 0;
 	differentialpath path;
-	for (int t = -3; t <= steps+1; ++t)
+	std::vector<differentialpath> vecpath;
+	do {
+		--val; val &= mask;
+		msg1[0] = (msg1[0]&~mask) ^ val;
+		msg2[0] = msg1[0] + parameters.m_diff[0];
+		Q1[Qoff+0+1] = md5_step(0, Q1[Qoff+0], Q1[Qoff+0-1], Q1[Qoff+0-2], Q1[Qoff+0-3], msg1[0]);
+		Q2[Qoff+0+1] = md5_step(0, Q2[Qoff+0], Q2[Qoff+0-1], Q2[Qoff+0-2], Q2[Qoff+0-3], msg2[0]);
+		Q10 &= Q1[Qoff+0+1];
+		Q11 |= Q1[Qoff+0+1];
+		Q20 &= Q2[Qoff+0+1];
+		Q21 |= Q2[Qoff+0+1];
+
+		msg1[1] = xrng128();
+		msg2[1] = msg1[1] + parameters.m_diff[1];
+		Q1[Qoff+1+1] = md5_step(1, Q1[Qoff+1], Q1[Qoff+1-1], Q1[Qoff+1-2], Q1[Qoff+1-3], msg1[1]);
+		Q2[Qoff+1+1] = md5_step(1, Q2[Qoff+1], Q2[Qoff+1-1], Q2[Qoff+1-2], Q2[Qoff+1-3], msg2[1]);
+		for (int t = -3; t <= 2; ++t)
+		{
+			for (unsigned b = 0; b < 32; ++b)
+			{
+				unsigned qtb1 = (Q1[Qoff+t]>>b)&1, qtb2 = (Q2[Qoff+t]>>b)&1;
+				if (qtb1 == 0 && qtb2 == 0)
+					path.setbitcondition(t,b,bc_zero);
+				else if (qtb1 == 1 && qtb2 == 1)
+					path.setbitcondition(t,b,bc_one);
+				else if (qtb1 == 0 && qtb2 == 1)
+					path.setbitcondition(t,b,bc_plus);
+				else if (qtb1 == 1 && qtb2 == 0)
+					path.setbitcondition(t,b,bc_minus);
+			}
+		}
+		path[2] = naf(path[2].diff());
+		vecpath.emplace_back(path);
+	} while (val != 0);
+
+	uint32 keepmask = 0;
+	for (unsigned b = 0; b < 32; ++b)
 	{
+		if (((Q10>>b)&1) == ((Q11>>b)&1))
+			keepmask |= uint32(1)<<b;
+		if (((Q20>>b)&1) == ((Q21>>b)&1))
+			keepmask |= uint32(1)<<b;
+	}
+	for (auto& path : vecpath)
+	{
+		uint32 Q11val = 0, Q11mask = ~uint32(0);
+		for (unsigned b = 0; b < 32; ++b)
+			if (path(1,b) == bc_one || path(1,b) == bc_minus)
+				Q11val |= uint32(1)<<b;
+
 		for (unsigned b = 0; b < 32; ++b)
 		{
-			unsigned qtb1 = (Q1[Qoff+t]>>b)&1, qtb2 = (Q2[Qoff+t]>>b)&1;
-			if (qtb1 == 0 && qtb2 == 0)
-				path.setbitcondition(t,b,bc_zero);
-			else if (qtb1 == 1 && qtb2 == 1)
-				path.setbitcondition(t,b,bc_one);
-			else if (qtb1 == 0 && qtb2 == 1)
-				path.setbitcondition(t,b,bc_plus);
-			else if (qtb1 == 1 && qtb2 == 0)
-				path.setbitcondition(t,b,bc_minus);
+			if (path(1,b) == bc_plus || path(1,b) == bc_minus || ((keepmask>>b)&1))
+				continue;
+			bitcondition oldbc = path(1,b);
+			path.setbitcondition(1,b,bc_constant);
+			if (!test_path_fast(path,parameters.m_diff))
+			{
+				path.setbitcondition(1,b,oldbc);
+				continue;
+			}
+			bool good = true;
+			Q11mask ^= uint32(1) <<b; // clear bit b
+			val = 0;
+			do {
+				--val; val &= ~Q11mask;
+				Q1[Qoff+1] = (Q11val & Q11mask) ^ val;
+				// uint32 md5_step_bw(unsigned t, uint32 Qtp1, uint32 Qtm0, uint32 Qtm1, uint32 Qtm2, uint32 Qtm3)
+				uint32 m0 = md5_step_bw(0, Q1[Qoff+1], Q1[Qoff+0], Q1[Qoff+0-1], Q1[Qoff+0-2], Q1[Qoff+0-3]);
+				if ((m0 ^ msg1[0]) & ~mask)
+				{
+					good = false;
+					break;
+				}
+			} while (val != 0);
+			if (!good)
+			{
+				path.setbitcondition(1,b,oldbc);
+				Q11mask ^= uint32(1) <<b; // set bit b again
+			}
 		}
 	}
-	path[steps+1] = naf(path[steps+1].diff());
-	cout << endl << "Parsed path:" << endl;
-	show_path(path, parameters.m_diff);
-	vector<differentialpath> vecpath;
-	vecpath.push_back(path);
+	std::sort(vecpath.begin(), vecpath.end());
+	vecpath.erase( std::unique(vecpath.begin(),vecpath.end()), vecpath.end());
+	show_path(vecpath.front(), parameters.m_diff);
 	cout << "Saving " << parameters.outfile2 << "..." << flush;
 	try {
 		save_gz(vecpath, binary_archive, parameters.outfile2);

--- a/src/md5helper/main.cpp
+++ b/src/md5helper/main.cpp
@@ -78,6 +78,7 @@ int main(int argc, char** argv)
 			("join,j", po::value<vector<string> >(&parameters.files),
 									"Join files and save to outputfile1\n"
 									"Each filename has to be proceeded by -j\n")
+			("combinepaths", "Use the first partial path in inputfile2 to overwrite all paths in inputfile1\n")
 			("pathfromtext",		"Load path in text form from inputfile1\n"
 									"   and save as paths set to outputfile1\n")
 			("pathfromcollision",	"Reconstruct paths from colliding inputfiles")
@@ -157,6 +158,7 @@ int main(int argc, char** argv)
 					+vm.count("convert")
 					+vm.count("split")
 					+vm.count("join")
+					+vm.count("combinepaths")
 					+vm.count("pathfromtext")
 					+vm.count("pathfromcollision")
 					+vm.count("startpartialpathfromfile")
@@ -190,6 +192,8 @@ int main(int argc, char** argv)
 			return split(parameters);
 		if (vm.count("join"))
 			return join(parameters);
+		if (vm.count("combinepaths"))
+			return combinepaths(parameters);
 		if (vm.count("pathfromtext"))
 			return pathfromtext(parameters);
 		if (vm.count("pathfromcollision"))

--- a/src/md5helper/main.cpp
+++ b/src/md5helper/main.cpp
@@ -79,6 +79,7 @@ int main(int argc, char** argv)
 									"Join files and save to outputfile1\n"
 									"Each filename has to be proceeded by -j\n")
 			("combinepaths", "Use the first partial path in inputfile2 to overwrite all paths in inputfile1\n")
+			("negatepaths", "Negate paths for negated message differences\n")
 			("pathfromtext",		"Load path in text form from inputfile1\n"
 									"   and save as paths set to outputfile1\n")
 			("pathfromcollision",	"Reconstruct paths from colliding inputfiles")
@@ -159,6 +160,7 @@ int main(int argc, char** argv)
 					+vm.count("split")
 					+vm.count("join")
 					+vm.count("combinepaths")
+					+vm.count("negatepaths")
 					+vm.count("pathfromtext")
 					+vm.count("pathfromcollision")
 					+vm.count("startpartialpathfromfile")
@@ -194,6 +196,8 @@ int main(int argc, char** argv)
 			return join(parameters);
 		if (vm.count("combinepaths"))
 			return combinepaths(parameters);
+		if (vm.count("negatepaths"))
+			return negatepaths(parameters);
 		if (vm.count("pathfromtext"))
 			return pathfromtext(parameters);
 		if (vm.count("pathfromcollision"))

--- a/src/md5helper/main.hpp
+++ b/src/md5helper/main.hpp
@@ -64,6 +64,7 @@ int convert(parameters_type& parameters);
 int split(parameters_type& parameters);
 int join(parameters_type& parameters);
 int combinepaths(parameters_type& parameters);
+int negatepaths(parameters_type& parameters);
 int pathfromtext(parameters_type& parameters);
 int pathfromcollision(parameters_type& parameters);
 int collisionfinding(parameters_type& parameters);

--- a/src/md5helper/main.hpp
+++ b/src/md5helper/main.hpp
@@ -63,6 +63,7 @@ int startnearcollision(parameters_type& parameters);
 int convert(parameters_type& parameters);
 int split(parameters_type& parameters);
 int join(parameters_type& parameters);
+int combinepaths(parameters_type& parameters);
 int pathfromtext(parameters_type& parameters);
 int pathfromcollision(parameters_type& parameters);
 int collisionfinding(parameters_type& parameters);

--- a/src/md5helper/startnearcollision.cpp
+++ b/src/md5helper/startnearcollision.cpp
@@ -434,7 +434,7 @@ int startnearcollision(parameters_type& parameters)
 			uint32 dihvmin[4] = { -dihv[0], -dihv[1], -dihv[2], -dihv[3] };
 			constructupperpath_sbcpc(upperpath, m_diff, dihvmin);
 		} else {
-			upperpath[32].clear();
+			upperpath[34].clear();
 			constructupperpath(upperpath, dm11[j], ncdiff[j].first, ncdiff[j].second);
 		}
 		if (upperpath.nrcond() < bestcond) {


### PR DESCRIPTION
- (for speed: forward): progressively increase output set size for the first few steps (t=1,2,3) of forward. this speeds up these first few steps considerably without loss of quality
- (fix forward, backward, connect): make dostep_index volatile, read it at start, write it at end of critical section.
- (improvement for helper): add better support to fix a few bytes at the start of a near-collision block to support more format-restricted usecases for chosen-prefix collisions.
- (for speed: helper): add support to negate a set of diffpaths, in order to negate each 'positive delta m_11'-based precomputed set of upper differential paths instead also computing the 'negate delta m_11'-based set.
- (for speed: helper): add support to combine diffpaths, in order to use precomputed set of upper differential paths and overwrite the full differential paths with the correct ending differences for the near-collision block at hand.
- (fix md5helper): add support to join files consisting of just a differentialpath
- (for scaling & latency: forward): add splitsave parameter to save output over multiple files (for multiple connect processes) in parallel
- (for speed: forward): when full decrease maxcond to stop processing paths that will be pruned later on anyway.
- (for speed: forward): use C++ move instead of copy, as that is faster
- (for scaling: forward): use threadlocal buffers to global container to reduce contention
- (for speed: connect): new mintunnel parameter to prune search from start to avoid bad full paths with too few tunnels, minor code improvements
- (for latency: connect): do parallel read of both inputfiles & new option waitinputfile to wait for each inputfile to exist before trying to load it
- (for scaling: forward, backward, connect): improve input distribution over threads, reducing contention
- (fix avx256 allocation: birthday): older GCCs (like on servers) might not propely do large alignment as required for AVX256
- (for latency: birthday): immediately save birthday collision when found, instead of waiting till all threads finish
- (for scaling: birthday): add saveloadwait parameter that controls how frequently trails are distributed to controllers (saved) and loaded by controllers (load)
- (for scaling: birthday): add generatormode that only generates trails and distributes them to controllers
- (for latency: lib): compressed diffpath archives: configure gzip for best_speed
- (for speed: lib, forward, backward): diffpath fast check solvability: only check changed part
- MacOS fix: differentialpath: clean up operators